### PR TITLE
Added support for Java 8 time classes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: scala
 scala:
   - 2.11.7
+jdk:
+  - oraclejdk8
 
 script:
   - sbt +clean coverage +test coverageReport

--- a/src/main/scala/org/scalacheck/ops/package.scala
+++ b/src/main/scala/org/scalacheck/ops/package.scala
@@ -1,5 +1,6 @@
 package org.scalacheck
 
+import org.scalacheck.ops.time.JavaTimeImplicits
 import org.scalacheck.ops.time.joda.JodaTimeImplicits
 
 /**
@@ -7,4 +8,4 @@ import org.scalacheck.ops.time.joda.JodaTimeImplicits
  *       date / time library for Java / Scala. This may change in future versions if this is
  *       somehow no longer the case.
  */
-package object ops extends ScalaCheckImplicits with JodaTimeImplicits
+package object ops extends ScalaCheckImplicits with JodaTimeImplicits with JavaTimeImplicits

--- a/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
+++ b/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
@@ -1,0 +1,57 @@
+package org.scalacheck.ops.time
+
+import java.time.chrono._
+import java.time.{Instant, LocalDateTime, ZoneOffset, ZonedDateTime}
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen._
+
+object ImplicitJavaTimeGenerators extends ImplicitJavaTimeGenerators
+trait ImplicitJavaTimeGenerators {
+
+  implicit val arbChronology: Arbitrary[Chronology] = {
+    Arbitrary(oneOf(Seq(
+      HijrahChronology.INSTANCE,
+      IsoChronology.INSTANCE,
+      JapaneseChronology.INSTANCE,
+      MinguoChronology.INSTANCE,
+      ThaiBuddhistChronology.INSTANCE
+    )))
+  }
+
+  implicit val arbZoneOffset: Arbitrary[ZoneOffset] = {
+    Arbitrary {
+      for {
+        totalSeconds <- chooseNum(ZoneOffset.MIN.getTotalSeconds, ZoneOffset.MAX.getTotalSeconds)
+      } yield ZoneOffset.ofTotalSeconds(totalSeconds)
+    }
+  }
+
+  implicit val arbInstant: Arbitrary[Instant] = {
+    Arbitrary {
+      for {
+        millis <- chooseNum(0L, Instant.MAX.getEpochSecond)
+        nanos <- chooseNum(0, Instant.MAX.getNano)
+      } yield {
+        Instant.ofEpochMilli(millis).plusNanos(nanos)
+      }
+    }
+  }
+
+  implicit val arbLocalDateTime: Arbitrary[LocalDateTime] = {
+    Arbitrary {
+      for {
+        instant <- arbInstant.arbitrary
+      } yield LocalDateTime.from(instant)
+    }
+  }
+
+  implicit def arbZonedDateTime(implicit params: JavaTimeParams = JavaTimeGenerators.defaultParams): Arbitrary[ZonedDateTime] = {
+    Arbitrary {
+      for {
+        instant <- arbInstant.arbitrary
+      } yield ZonedDateTime.from(instant).withZoneSameInstant(params.zoneOffset)
+    }
+  }
+
+}

--- a/src/main/scala/org/scalacheck/ops/time/JavaTimeGenerators.scala
+++ b/src/main/scala/org/scalacheck/ops/time/JavaTimeGenerators.scala
@@ -1,0 +1,46 @@
+package org.scalacheck.ops.time
+
+import java.time.temporal._
+import java.time.{Duration, Instant}
+
+object JavaTimeGenerators extends JavaTimeGenerators
+trait JavaTimeGenerators extends AbstractDateTimeGenerators {
+  override type DateTimeType = Instant
+  override type DurationType = TemporalAmount
+  override type ParamsType = JavaTimeParams
+
+  override protected[time] def datetime(millis: Long)
+    (implicit params: JavaTimeParams): Instant = Instant.ofEpochMilli(millis)
+
+  override protected[time] def duration(millis: Long): TemporalAmount = Duration.ofMillis(millis)
+
+  override protected[time] def millis(duration: TemporalAmount): Long = {
+    // some durations don't support MILLIS, but all support NANOS
+    duration.get(ChronoUnit.NANOS) / 1000
+  }
+
+  override protected[time] def millis(datetime: Instant)
+    (implicit params: JavaTimeParams): Long = datetime.toEpochMilli
+
+  override protected[time] def addToCeil(
+    datetime: Instant,
+    duration: TemporalAmount
+  )(implicit params: JavaTimeParams): Instant = {
+    try datetime plus duration
+    catch {
+      case ex: ArithmeticException => Instant.MAX
+    }
+  }
+
+  override protected[time] def subtractToFloor(
+    datetime: Instant,
+    duration: TemporalAmount
+  )(implicit params: JavaTimeParams): Instant = {
+    try datetime minus duration
+    catch {
+      case ex: ArithmeticException => Instant.MIN
+    }
+  }
+
+  override def defaultParams: JavaTimeParams = JavaTimeParams.isoUTC
+}

--- a/src/main/scala/org/scalacheck/ops/time/JavaTimeImplicits.scala
+++ b/src/main/scala/org/scalacheck/ops/time/JavaTimeImplicits.scala
@@ -1,0 +1,16 @@
+package org.scalacheck.ops.time
+
+import org.scalacheck.Gen
+
+import scala.language.implicitConversions
+
+object JavaTimeImplicits extends JavaTimeImplicits
+trait JavaTimeImplicits {
+
+  implicit def toJavaTimeGenOps(gen: Gen.type): JavaTimeGenOps.type = JavaTimeGenOps
+}
+
+object JavaTimeGenOps {
+
+  def instant: JavaTimeGenerators = JavaTimeGenerators
+}

--- a/src/main/scala/org/scalacheck/ops/time/JavaTimeParams.scala
+++ b/src/main/scala/org/scalacheck/ops/time/JavaTimeParams.scala
@@ -1,0 +1,14 @@
+package org.scalacheck.ops.time
+
+import java.time.ZoneOffset
+import java.time.chrono.{Chronology, IsoChronology}
+
+case class JavaTimeParams(chronology: Chronology, zoneOffset: ZoneOffset)
+
+object JavaTimeParams {
+
+  val isoUTC = JavaTimeParams(IsoChronology.INSTANCE, ZoneOffset.UTC)
+
+  implicit def fromImplicits(implicit chronology: Chronology, zoneOffset: ZoneOffset): JavaTimeParams =
+    new JavaTimeParams(chronology, zoneOffset)
+}

--- a/src/test/scala/org/scalacheck/ops/time/JavaInstantGeneratorsSpec.scala
+++ b/src/test/scala/org/scalacheck/ops/time/JavaInstantGeneratorsSpec.scala
@@ -1,0 +1,13 @@
+package org.scalacheck.ops.time
+
+import java.time.Instant
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.ops.time.ImplicitJavaTimeGenerators._
+
+import scala.reflect.ClassTag
+
+class JavaInstantGeneratorsSpec extends GenericDateTimeGeneratorsSpec(JavaTimeGenerators, "JavaInstantGenerators") {
+  override protected val arbDateTimeType: Arbitrary[Instant] = implicitly[Arbitrary[Instant]]
+  override protected val clsTagDateTimeType: ClassTag[Instant] = implicitly[ClassTag[Instant]]
+}


### PR DESCRIPTION
@chrissalij-r @egprentice @PainterAndHacker @audax-shreyaspurohit @htmldoug

I added basic Java 8 support. I plan to refactor Joda out of the core of the library, but I wanted to provide a temporary minor release so people could make the transition to Java 8 time without having to make the upgrade to all shared libraries before taking advantage of basic support for this feature.
