### PR TITLE
Add git-versioning-sbt-plugin and upgrade library versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,102 +1,85 @@
+// Aggregate root project settings only
+name := "scalacheck-ops-root"
+// don't publish the aggregate root project
+publish := {}
+publishLocal := {}
 
-val commonRootSettings = Seq(
-  name := "scalacheck-ops",
-  organization := "me.jeffmay",
-  organizationName := "Jeff May",
-  version := "1.6.0",
+organization in ThisBuild := "me.jeffmay"
+organizationName in ThisBuild := "Jeff May"
 
-  // scala version for root project
-  scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.11.8", "2.10.6"),
+semVerLimit in ThisBuild := "1.999.999"
 
-  licenses += ("Apache-2.0", url("http://opensource.org/licenses/apache-2.0"))
-)
+scalaVersion in ThisBuild := "2.11.8"
+crossScalaVersions in ThisBuild := Seq("2.11.8", "2.10.6")
 
-lazy val root = (project in file("."))
-  .settings(commonRootSettings)
-  .settings(
-    name := "scalacheck-ops-root",
-    // don't publish the surrounding multi-project root
-    publish := {},
-    publishLocal := {}
-  )
-  .aggregate(`core_1-12`, `core_1-13`)
+licenses in ThisBuild += ("Apache-2.0", url("http://opensource.org/licenses/apache-2.0"))
 
-// the version of scalacheck, all cross-compiled settings are derived from this setting
-lazy val scalacheckVersion = settingKey[String]("version of scalacheck (all cross-compiled settings are derived from this setting)")
+resolvers in ThisBuild += "jeffmay" at "https://dl.bintray.com/jeffmay/maven"
 
-// using scalatest version 3.0.0 should be no problem
-lazy val scalatestVersion = settingKey[String]("version of scalatest")
+def commonProject(id: String, artifact: String, path: String): Project = {
+  Project(id, file(path)).settings(
+    name := artifact,
 
-/**
-  * Choose one value or another based on the version of scalacheck.
-  */
-def basedOnVersion[T](version: String, old: T, latest: T): T = {
-  if (version startsWith "1.12.") old else latest
+    scalacOptions := {
+      // the deprecation:false flag is only supported by scala >= 2.11.3, but needed for scala >= 2.11.0 to avoid warnings
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, scalaMinor)) if scalaMinor >= 11 =>
+          // For scala versions >= 2.11.3
+          Seq("-Xfatal-warnings", "-deprecation:false")
+        case Some((2, scalaMinor)) if scalaMinor < 11 =>
+          // For scala versions 2.10.x
+          Seq("-Xfatal-warnings")
+      }
+    } ++ Seq(
+      "-feature",
+      "-Xlint",
+      "-Ywarn-dead-code",
+      "-encoding", "UTF-8"
+    ),
+
+    // show full stack traces in test failures ()
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
+
+    // force scala version
+    ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
+
+    // disable compilation of ScalaDocs, since this always breaks on links and isn't as helpful as source
+    sources in(Compile, doc) := Seq.empty,
+
+    // disable publishing empty ScalaDocs
+    publishArtifact in (Compile, packageDoc) := false
+
+  ).enablePlugins(SemVerPlugin)
 }
 
-val commonSettings = commonRootSettings ++ Seq(
-
-  // scalatest 2.2.6 pulls in scalacheck and it only works with 1.12.5
-  // if you want to pull in the latest version, you should be fine to pull in scalacheck 1.13.x
-  scalatestVersion := basedOnVersion(scalacheckVersion.value, "2.2.6", "3.0.0"),
-
-  scalacOptions := {
-    // the deprecation:false flag is only supported by scala >= 2.11.3, but needed for scala >= 2.11.0 to avoid warnings
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, scalaMinor)) if scalaMinor >= 11 =>
-        // For scala versions >= 2.11.3
-        Seq("-Xfatal-warnings", "-deprecation:false")
-      case Some((2, scalaMinor)) if scalaMinor < 11 =>
-        // For scala versions 2.10.x
-        Seq("-Xfatal-warnings")
-    }
-  } ++ Seq(
-    "-feature",
-    "-Xlint",
-    "-Ywarn-dead-code",
-    "-encoding", "UTF-8"
-  ),
-
-  libraryDependencies ++= Seq(
-    // pull in the specified version of scalacheck
-    "org.scalacheck" %% "scalacheck" % scalacheckVersion.value,
-    // scalatest 2.2.6 pulls in scalacheck 1.12.5 so it only works with 1.12.5
-    "org.scalatest" %% "scalatest" % scalatestVersion.value % Test
-  ),
-
-  // show full stack traces in test failures ()
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
-
-  // force scala version
-  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
-
-  // disable compilation of ScalaDocs, since this always breaks on links and isn't as helpful as source
-  sources in(Compile, doc) := Seq.empty,
-
-  // disable publishing empty ScalaDocs
-  publishArtifact in (Compile, packageDoc) := false
-)
-
-val coreSettings = commonSettings ++ Seq(
-  sourceDirectory := file("core/src").getAbsoluteFile,
-  libraryDependencies ++= Seq(
-    "org.joda" % "joda-convert" % "1.8",
-    "joda-time" % "joda-time" % "2.9.4"
+def coreProject(scalaCheckVersion: String): Project = {
+  // TODO: Simplify this by publishing the 1.12 branch as _1-12 and naming the directory the same
+  // All future versions should be > 1.13 and have no suffix
+  val pathSuffix = scalaCheckVersion match {
+    case Dependencies.scalaCheck12Version => ""
+    case Dependencies.scalaCheck13Version => "_1.13"
+  }
+  val artifactSuffix = scalaCheckVersion match {
+    case Dependencies.scalaCheck12Version => ""
+    case Dependencies.scalaCheck13Version => "_1-13"
+  }
+  val idSuffix = scalaCheckVersion match {
+    case Dependencies.scalaCheck12Version => "_1-12"
+    case Dependencies.scalaCheck13Version => "_1-13"
+  }
+  commonProject(s"core$idSuffix", s"scalacheck-ops$artifactSuffix", s"core$pathSuffix").settings(
+    sourceDirectory := file("core/src").getAbsoluteFile,
+    libraryDependencies ++= Seq(
+      Dependencies.scalaCheck(scalaCheckVersion),
+      Dependencies.jodaConvert,
+      Dependencies.jodaTime
+    ) ++ Seq(
+      // Test-only dependencies
+      Dependencies.scalaTest(scalaCheckVersion)
+    ).map(_ % Test)
   )
-)
+}
 
-lazy val `core_1-12` = (project in file("core"))
-  .settings(coreSettings: _*)
-  .settings(
-    name := "scalacheck-ops",
-    scalacheckVersion := "1.12.5"
-  )
-
-lazy val `core_1-13` = (project in file("core_1.13"))
-  .settings(coreSettings: _*)
-  .settings(
-    name := "scalacheck-ops_1.13",
-    scalacheckVersion := "1.13.2"
-  )
+lazy val `core_1-12` = coreProject(Dependencies.scalaCheck12Version)
+lazy val `core_1-13` = coreProject(Dependencies.scalaCheck13Version)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,29 @@
+import sbt._
+import sbt.Keys._
+
+object Dependencies {
+
+  final val scalaCheck12Version = "1.12.5"
+  final val scalaCheck13Version = "1.13.2"
+
+  private val scalaTest2Version = "2.2.6"
+  private val scalaTest3Version = "3.0.0"
+
+  private val jodaTimeVersion = "1.8"
+
+  val jodaConvert: ModuleID = "org.joda" % "joda-convert" % "1.8"
+  val jodaTime: ModuleID = "joda-time" % "joda-time" % "2.9.4"
+
+  def scalaCheck(scalaCheckVersion: String): ModuleID = {
+    "org.scalacheck" %% "scalacheck" % scalaCheckVersion
+  }
+
+  def scalaTest(scalaCheckVersion: String): ModuleID = {
+    val scalaTestVersion = scalaCheckVersion match {
+      case `scalaCheck12Version` => scalaTest2Version
+      case `scalaCheck13Version` => scalaTest3Version
+    }
+    "org.scalatest" %% "scalatest" % scalaTestVersion
+  }
+}
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,11 @@ import sbt.Keys._
 
 object Dependencies {
 
-  final val scalaCheck12Version = "1.12.5"
-  final val scalaCheck13Version = "1.13.2"
+  final val scalaCheck12Version = "1.12.6"
+  final val scalaCheck13Version = "1.13.4"
 
   private val scalaTest2Version = "2.2.6"
-  private val scalaTest3Version = "3.0.0"
+  private val scalaTest3Version = "3.0.4"
 
   private val jodaTimeVersion = "1.8"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,17 @@
 resolvers += Classpaths.sbtPluginReleases
 
 resolvers += Resolver.url(
+  "Rally Plugin Releases",
+  url("https://dl.bintray.com/rallyhealth/sbt-plugins")
+)(Resolver.ivyStylePatterns)
+
+resolvers += Resolver.url(
   "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-    Resolver.ivyStylePatterns)
+  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases")
+)(Resolver.ivyStylePatterns)
 
+addSbtPlugin("com.rallyhealth.sbt" % "git-versioning-sbt-plugin" % "0.0.2")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
-
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 


### PR DESCRIPTION
@gloriousfutureio/scalanauts @rcmurphy @htmldoug

- Add semantic version validation
- Automatic version derivation based on git tags
- This refactors the build.sbt to match other projects. This new style works better with plugins.
- Upgrade libraries to latest patch versions