### PR TITLE
Upgrade joda time library and remove joda convert

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,6 @@ def jodaProject(scalaCheckVersion: String): Project = {
     (sourceDirectory in Test) := file(s"$projectPath/src/test").getAbsoluteFile,
     libraryDependencies ++= Seq(
       Dependencies.scalaCheck(scalaCheckVersion),
-      Dependencies.jodaConvert,
       Dependencies.jodaTime
     ) ++ Seq(
       // Test-only dependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,10 +9,8 @@ object Dependencies {
   private val scalaTest2Version = "2.2.6"
   private val scalaTest3Version = "3.0.4"
 
-  private val jodaTimeVersion = "2.9.4"
+  private val jodaTimeVersion = "2.10"
 
-  // Necessary to fix an issue with a missing transitive dependency for older versions of ScalaCheck
-  val jodaConvert: ModuleID = "org.joda" % "joda-convert" % "1.8"
   val jodaTime: ModuleID = "joda-time" % "joda-time" % jodaTimeVersion
 
   def scalaCheck(scalaCheckVersion: String): ModuleID = {


### PR DESCRIPTION
@gloriousfutureio/scalanauts @rcmurphy 

I figure since this is a major change, we might as well upgrade Joda. It doesn't seem to cause any issues with Play (I pulled this snapshot into another app locally to test).