### PR TITLE
Support scalacheck 1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 </a>
 <table>
   <tr>
-    <th>scalacheck-ops</th>
+    <th>scalacheck-ops (1.x)</th>
+    <th>scalacheck-ops_1-12</th>
     <th>scalacheck-ops_1-13</th>
+    <th>scalacheck-ops_1-14</th>
   </tr>
   <tr>
     <td>
@@ -16,36 +18,72 @@
       </a>
     </td>
     <td>
+      <a href='https://bintray.com/jeffmay/maven/scalacheck-ops_1-12/_latestVersion'>
+        <img src='https://api.bintray.com/packages/jeffmay/maven/scalacheck-ops_1-12/images/download.svg'>
+      </a>
+    </td>
+    <td>
       <a href='https://bintray.com/jeffmay/maven/scalacheck-ops_1-13/_latestVersion'>
         <img src='https://api.bintray.com/packages/jeffmay/maven/scalacheck-ops_1-13/images/download.svg'>
+      </a>
+    </td>
+    <td>
+      <a href='https://bintray.com/jeffmay/maven/scalacheck-ops_1-14/_latestVersion'>
+        <img src='https://api.bintray.com/packages/jeffmay/maven/scalacheck-ops_1-14/images/download.svg'>
       </a>
     </td>
   </tr>
 </table>
 
-# scalacheck-ops
+# Summary
 
-Common [ScalaCheck](https://www.scalacheck.org/) implicits and helper 
+A library that provides [ScalaCheck](https://www.scalacheck.org/) implicits and helper 
 methods made available via:
 ```scala
 import org.scalacheck.ops._
 ```
 
-## scalacheck-ops_1-13
+See the [use cases section](#use-cases) for use cases and operations that are enabled 
+with scalacheck-ops.
 
-The additional `scalacheck-ops_1-13` library is compiled against 
-ScalaCheck 1.13.x branch because it contains some binary 
-incompatibilities. Specifically, when mixing this library with ScalaTest
-3.x you might notice the following exception:
+# Installation
+
+### Compatibility
+
+**NOTE** Version 2.x and above **requires** JDK >=8 and Scala >=2.11 as this 
+library expects the java.time standard library module.
+
+**NOTE** As of `scalacheck-ops` >=2.0, the version of scalacheck is always
+included in the artifact name. Prior to this change, `scalacheck-ops` with
+no version suffix would pull in ScalaCheck version 1.12.6. 
+
+| Artifact Name       | Version Limit  | ScalaCheck | Supported JDK | Supported Scala |
+| :-----------------: | :------------: | :--------: | :-----------: | :-------------: |
+| scalacheck-ops_1-14 | x >= 2.0       |     1.14.0 | 8             | 2.11            |
+| scalacheck-ops_1-13 | x >= 2.0       |     1.13.4 | 8             | 2.11            |
+| scalacheck-ops_1-13 | 1.5 <= x < 2.0 |     1.13.4 | 6 - 8         | 2.10 - 2.11     |
+| scalacheck-ops_1-12 | x >= 2.0       |     1.12.6 | 8             | 2.11            |
+| scalacheck-ops      | x < 2.0        |     1.12.6 | 6 - 8         | 2.10 - 2.11     |
+
+The same source code is compiled against specific versions of Scala and ScalaCheck. 
+We use separate artifacts to avoid causing issues with transitive dependencies on
+ScalaCheck being evicted with binary incompatible versions.
+
+### ScalaTest Compatibility
+
+Specifically, when using this library with ScalaTest you might notice the 
+following exception:
 
 ```
 java.lang.IncompatibleClassChangeError: Found class org.scalacheck.Gen, but interface was expected
 ```
 
-## Prerequisites
+This is because you need `scalacheck-ops_1-13` for ScalaTest 3.0.x
 
-Version of scalacheck-ops >2.x requires JDK >8 and Scala >2.11 as this 
-library expects the java.time standard library module.
+| ScalaTest Version | ScalaCheck Version |
+| :---------------: | :----------------: |
+|             2.2.x |             1.12.6 |
+|             3.0.x |             1.13.4 |
 
 # Use Cases
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,23 +43,16 @@ def commonProject(id: String, artifact: String, path: String): Project = {
   ).enablePlugins(GitVersioningPlugin, SemVerPlugin)
 }
 
+def suffixFor(scalaCheckVersion: String): String = scalaCheckVersion match {
+  case Dependencies.scalaCheck12Version => "_1-12"
+  case Dependencies.scalaCheck13Version => "_1-13"
+  case Dependencies.scalaCheck14Version => "_1-14"
+}
+
 def coreProject(scalaCheckVersion: String): Project = {
-  // TODO: Simplify this by publishing the 1.12 branch as _1-12 and naming the directory the same
-  // All future versions should be > 1.13 and have no suffix
-  val projectPath = s"core"
-  val pathSuffix = scalaCheckVersion match {
-    case Dependencies.scalaCheck12Version => "_1.12"
-    case Dependencies.scalaCheck13Version => "_1.13"
-  }
-  val artifactSuffix = scalaCheckVersion match {
-    case Dependencies.scalaCheck12Version => ""
-    case Dependencies.scalaCheck13Version => "_1-13"
-  }
-  val idSuffix = scalaCheckVersion match {
-    case Dependencies.scalaCheck12Version => "_1-12"
-    case Dependencies.scalaCheck13Version => "_1-13"
-  }
-  commonProject(s"core$idSuffix", s"scalacheck-ops$artifactSuffix", s"$projectPath$pathSuffix").settings(
+  val projectPath = "core"
+  val suffix = suffixFor(scalaCheckVersion)
+  commonProject(s"core$suffix", s"scalacheck-ops$suffix", s"$projectPath$suffix").settings(
     sourceDirectory := file(s"$projectPath/src").getAbsoluteFile,
     (sourceDirectory in Compile) := file(s"$projectPath/src/main").getAbsoluteFile,
     (sourceDirectory in Test) := file(s"$projectPath/src/test").getAbsoluteFile,
@@ -74,24 +67,12 @@ def coreProject(scalaCheckVersion: String): Project = {
 
 lazy val `core_1-12` = coreProject(Dependencies.scalaCheck12Version)
 lazy val `core_1-13` = coreProject(Dependencies.scalaCheck13Version)
+lazy val `core_1-14` = coreProject(Dependencies.scalaCheck14Version)
 
 def jodaProject(scalaCheckVersion: String): Project = {
-  // TODO: Simplify this by publishing the 1.12 branch as _1-12 and naming the directory the same
-  // All future versions should be > 1.13 and have no suffix
-  val projectPath = s"joda"
-  val pathSuffix = scalaCheckVersion match {
-    case Dependencies.scalaCheck12Version => "_1.12"
-    case Dependencies.scalaCheck13Version => "_1.13"
-  }
-  val artifactSuffix = scalaCheckVersion match {
-    case Dependencies.scalaCheck12Version => ""
-    case Dependencies.scalaCheck13Version => "_1-13"
-  }
-  val idSuffix = scalaCheckVersion match {
-    case Dependencies.scalaCheck12Version => "_1-12"
-    case Dependencies.scalaCheck13Version => "_1-13"
-  }
-  commonProject(s"joda$idSuffix", s"scalacheck-ops-joda$artifactSuffix", s"$projectPath$pathSuffix").settings(
+  val projectPath = "joda"
+  val suffix = suffixFor(scalaCheckVersion)
+  commonProject(s"joda$suffix", s"scalacheck-ops-joda$suffix", s"$projectPath$suffix").settings(
     sourceDirectory := file(s"$projectPath/src").getAbsoluteFile,
     (sourceDirectory in Compile) := file(s"$projectPath/src/main").getAbsoluteFile,
     (sourceDirectory in Test) := file(s"$projectPath/src/test").getAbsoluteFile,
@@ -103,10 +84,15 @@ def jodaProject(scalaCheckVersion: String): Project = {
       Dependencies.scalaTest(scalaCheckVersion)
     ).map(_ % Test)
   ).dependsOn(
-    (if (scalaCheckVersion.startsWith("1.12")) `core_1-12` else `core_1-13`) % "compile;test->test"
+    (scalaCheckVersion match {
+      case Dependencies.scalaCheck12Version => `core_1-12`
+      case Dependencies.scalaCheck13Version => `core_1-13`
+      case Dependencies.scalaCheck14Version => `core_1-14`
+    }) % "compile;test->test"
   )
 }
 
 lazy val `joda_1-12` = jodaProject(Dependencies.scalaCheck12Version)
 lazy val `joda_1-13` = jodaProject(Dependencies.scalaCheck13Version)
+lazy val `joda_1-14` = jodaProject(Dependencies.scalaCheck14Version)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,9 +5,10 @@ object Dependencies {
 
   final val scalaCheck12Version = "1.12.6"
   final val scalaCheck13Version = "1.13.4"
+  final val scalaCheck14Version = "1.14.0"
 
   private val scalaTest2Version = "2.2.6"
-  private val scalaTest3Version = "3.0.4"
+  private val scalaTest3Version = "3.0.5"
 
   private val jodaTimeVersion = "2.10"
 
@@ -21,6 +22,7 @@ object Dependencies {
     val scalaTestVersion = scalaCheckVersion match {
       case `scalaCheck12Version` => scalaTest2Version
       case `scalaCheck13Version` => scalaTest3Version
+      case `scalaCheck14Version` => scalaTest3Version
     }
     "org.scalatest" %% "scalatest" % scalaTestVersion
   }


### PR DESCRIPTION
@gloriousfutureio/scalanauts @usufruct99 @rcmurphy @sklei2 

This is the last big breaking change before cutting the 2.0.0 release. After this, we will move the repo under com.rallyhealth organization and release it.