### PR TITLE
Fix broken bintrayEnsureBintrayPackageExists check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,10 @@ licenses in ThisBuild := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 
 val bintrayOrg = "rallyhealth"
 
-bintrayOrganization := Some(bintrayOrg)
+bintrayOrganization in ThisBuild := Some(bintrayOrg)
 bintrayRepository := "ivy-scala-libs"
 
-resolvers in ThisBuild += Resolver.bintrayRepo(bintrayOrg, bintrayRepository.value)
+resolvers in ThisBuild += Resolver.bintrayRepo(bintrayOrg, bintrayOrg)
 
 def commonProject(id: String, artifact: String, path: String): Project = {
   Project(id, file(path)).settings(


### PR DESCRIPTION
@rallyhealth/engineers 
@sklei2 

Apparently, I broke the credentials check with my last PR which only shows up when attempting to publish to bintray. This should fix it.

The error I was seeing:
```
java.lang.RuntimeException: was not able to find or create a package for jeffmay in Repo(jeffmay,ivy-scala-libs) named scalacheck-ops-joda_1-14
	at scala.sys.package$.error(package.scala:27)
	at bintray.BintrayRepo.ensurePackage(BintrayRepo.scala:51)
	at bintray.BintrayPlugin$$anonfun$ensurePackageTask$1.apply(BintrayPlugin.scala:179)
	at bintray.BintrayPlugin$$anonfun$ensurePackageTask$1.apply(BintrayPlugin.scala:174)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

It looks like it was using my default credentials file instead of the configs in this build.sbt for the projects to determine the organization name.