### PR TITLE
Publish to a maven style repo (renamed from ivy-scala-libs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@
       </a>
     </td>
     <td>
-      <a href='https://bintray.com/jeffmay/maven/scalacheck-ops_1-12/_latestVersion'>
-        <img src='https://api.bintray.com/packages/rallyhealth/ivy-scala-libs/scalacheck-ops_1-12/images/download.svg'>
+      <a href='https://bintray.com/rallyhealth/maven/scalacheck-ops_1-12/_latestVersion'>
+        <img src='https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-12/images/download.svg'>
       </a>
     </td>
     <td>
-      <a href='https://bintray.com/jeffmay/maven/scalacheck-ops_1-13/_latestVersion'>
-        <img src='https://api.bintray.com/packages/rallyhealth/ivy-scala-libs/scalacheck-ops_1-13/images/download.svg'>
+      <a href='https://bintray.com/rallyhealth/maven/scalacheck-ops_1-13/_latestVersion'>
+        <img src='https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-13/images/download.svg'>
       </a>
     </td>
     <td>
-      <a href='https://bintray.com/jeffmay/maven/scalacheck-ops_1-14/_latestVersion'>
-        <img src='https://api.bintray.com/packages/rallyhealth/ivy-scala-libs/scalacheck-ops_1-14/images/download.svg'>
+      <a href='https://bintray.com/rallyhealth/maven/scalacheck-ops_1-14/_latestVersion'>
+        <img src='https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-14/images/download.svg'>
       </a>
     </td>
   </tr>

--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,10 @@ semVerLimit in ThisBuild := "2.1.999"
 scalaVersion in ThisBuild := "2.11.11"
 licenses in ThisBuild := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 
-val bintrayOrg = "rallyhealth"
+bintrayOrganization := Some("rallyhealth")
+bintrayRepository := "maven"
 
-bintrayOrganization in ThisBuild := Some(bintrayOrg)
-bintrayRepository := "ivy-scala-libs"
-
-resolvers in ThisBuild += Resolver.bintrayRepo(bintrayOrg, bintrayOrg)
+resolvers in ThisBuild += Resolver.bintrayRepo("rallyhealth", "maven")
 
 def commonProject(id: String, artifact: String, path: String): Project = {
   Project(id, file(path)).settings(


### PR DESCRIPTION
@rallyhealth/engineers @usufruct99 

It appears that this has been publishing artifacts using Maven style patterns. Since this is the only Scala library (sbt plugins are published using Ivy patterns by default), I think the best course of action is to rename the bintray repository to `maven-scala-libs` or just `maven` (removing the `ivy-` prefix) and continuing to publish this library (and others) using maven patterns.

This will break any resolvers that are using `ivy-scala-libs`, but continuing the pattern of publishing maven style artifacts to a repo named with "ivy" will only continue the confusion. And changing the style moving forward would also break compatibility (as the user would have to change the resolver style in their sbt build to pick up new versions). I would be happy to backport artifacts to a new `ivy-scala-libs` repository (using ivy patterns, of course) if necessary, but I think this code is only used in one place (a project that I am working on that hasn't been released yet). Renaming the resolver makes the fix relatively simple, just rename the resolver from `ivy-scala-libs` to `maven` (the default) and all else should be the same.