### PR TITLE
Add support for Scala 2.12 and Scala 2.13.0-M4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ language: scala
 scala:
   - 2.11.11
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
-  - sbt clean coverage test coverageReport
+  - sbt clean coverage +test coverageReport && sbt coverageAggregate
 after_success:
-  - sbt 'project core_1-12' coveralls
+  # Upload coverage reports to codecov.io
+  - bash <(curl -s https://codecov.io/bash) -t 50d829ce-40d0-4fa4-8479-2e0f3864a07f
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/README.md
+++ b/README.md
@@ -1,39 +1,9 @@
-<a href='https://travis-ci.org/rallyhealth/scalacheck-ops'>
-  <img src='https://travis-ci.org/rallyhealth/scalacheck-ops.svg?branch=master' alt='Build Status' />
-</a>
-<a href='https://coveralls.io/github/rallyhealth/scalacheck-ops?branch=master'>
-  <img src='https://coveralls.io/repos/github/rallyhealth/scalacheck-ops/badge.svg?branch=master' alt='Coverage Status' />
-</a>
-<table>
-  <tr>
-    <th>scalacheck-ops (1.x)</th>
-    <th>scalacheck-ops_1-12</th>
-    <th>scalacheck-ops_1-13</th>
-    <th>scalacheck-ops_1-14</th>
-  </tr>
-  <tr>
-    <td>
-      <a href='https://bintray.com/jeffmay/maven/scalacheck-ops/_latestVersion'>
-        <img src='https://api.bintray.com/packages/jeffmay/maven/scalacheck-ops/images/download.svg'>
-      </a>
-    </td>
-    <td>
-      <a href='https://bintray.com/rallyhealth/maven/scalacheck-ops_1-12/_latestVersion'>
-        <img src='https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-12/images/download.svg'>
-      </a>
-    </td>
-    <td>
-      <a href='https://bintray.com/rallyhealth/maven/scalacheck-ops_1-13/_latestVersion'>
-        <img src='https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-13/images/download.svg'>
-      </a>
-    </td>
-    <td>
-      <a href='https://bintray.com/rallyhealth/maven/scalacheck-ops_1-14/_latestVersion'>
-        <img src='https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-14/images/download.svg'>
-      </a>
-    </td>
-  </tr>
-</table>
+[![Build Status](https://travis-ci.org/rallyhealth/scalacheck-ops.svg?branch=master)](https://travis-ci.org/rallyhealth/scalacheck-ops)
+[![codecov](https://codecov.io/gh/rallyhealth/scalacheck-ops/branch/master/graph/badge.svg)](https://codecov.io/gh/rallyhealth/scalacheck-ops)
+
+| scalacheck-ops (1.x) | scalacheck-ops_1-12 | scalacheck-ops_1-13 | scalacheck-ops_1-14 |
+| :------------------: | :-----------------: | :-----------------: | :-----------------: |
+| [ ![Download](https://api.bintray.com/packages/jeffmay/maven/scalacheck-ops/images/download.svg) ](https://bintray.com/jeffmay/maven/scalacheck-ops/_latestVersion) | [ ![Download](https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-12/images/download.svg) ](https://bintray.com/rallyhealth/maven/scalacheck-ops_1-12/_latestVersion) | [ ![Download](https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-13/images/download.svg) ](https://bintray.com/rallyhealth/maven/scalacheck-ops_1-13/_latestVersion) | [ ![Download](https://api.bintray.com/packages/rallyhealth/maven/scalacheck-ops_1-14/images/download.svg) ](https://bintray.com/rallyhealth/maven/scalacheck-ops_1-14/_latestVersion) |
 
 # Summary
 

--- a/joda/src/main/scala/org/scalacheck/ops/time/joda/ImplicitJodaTimeGenerators.scala
+++ b/joda/src/main/scala/org/scalacheck/ops/time/joda/ImplicitJodaTimeGenerators.scala
@@ -1,16 +1,17 @@
 package org.scalacheck.ops.time.joda
 
 import org.joda.time.chrono._
-import org.joda.time.{Chronology, DateTimeZone, DateTime, LocalDateTime}
+import org.joda.time.{Chronology, DateTime, DateTimeZone, LocalDateTime}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
 import org.scalacheck.ops.time.joda.ChronologyOps._
-import scala.collection.JavaConversions._
+
+import scala.collection.JavaConverters._
 
 trait ImplicitJodaTimeGenerators {
 
   implicit val arbDateTimeZone: Arbitrary[DateTimeZone] = {
-    val ids = DateTimeZone.getAvailableIDs.toSeq
+    val ids = DateTimeZone.getAvailableIDs.asScala.toSeq
     val zones = ids map DateTimeZone.forID
     Arbitrary(oneOf(zones))
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,16 +3,21 @@ import sbt.Keys._
 
 object Dependencies {
 
-  final val scalaCheck12Version = "1.12.6"
-  final val scalaCheck13Version = "1.13.4"
-  final val scalaCheck14Version = "1.14.0"
+  final val Scala_2_11 = "2.11.12"
+  final val Scala_2_12 = "2.12.6"
+  final val Scala_2_13 = "2.13.0-M4"
 
-  private val scalaTest2Version = "2.2.6"
-  private val scalaTest3Version = "3.0.5"
+  final val ScalaCheck_1_12 = "1.12.6"
+  final val ScalaCheck_1_13 = "1.13.5"
+  final val ScalaCheck_1_14 = "1.14.0"
 
-  private val jodaTimeVersion = "2.10"
+  private val ScalaTest_2 = "2.2.6"
+  private val ScalaTest_3 = "3.0.5"
+  private val ScalaTest_3_M4 = "3.0.6-SNAP2"
 
-  val jodaTime: ModuleID = "joda-time" % "joda-time" % jodaTimeVersion
+  private val JodaTimeVersion = "2.10"
+
+  val jodaTime: ModuleID = "joda-time" % "joda-time" % JodaTimeVersion
 
   def scalaCheck(scalaCheckVersion: String): ModuleID = {
     "org.scalacheck" %% "scalacheck" % scalaCheckVersion
@@ -20,9 +25,9 @@ object Dependencies {
 
   def scalaTest(scalaCheckVersion: String): ModuleID = {
     val scalaTestVersion = scalaCheckVersion match {
-      case `scalaCheck12Version` => scalaTest2Version
-      case `scalaCheck13Version` => scalaTest3Version
-      case `scalaCheck14Version` => scalaTest3Version
+      case ScalaCheck_1_12 => ScalaTest_2
+      case ScalaCheck_1_13 => ScalaTest_3
+      case ScalaCheck_1_14 => ScalaTest_3_M4
     }
     "org.scalatest" %% "scalatest" % scalaTestVersion
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,8 +10,6 @@ resolvers += Resolver.url(
   url("http://dl.bintray.com/content/sbt/sbt-plugin-releases")
 )(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.0.0")
+addSbtPlugin("com.rallyhealth.sbt" %% "sbt-git-versioning" % "1.2.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.6")
-
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M4")


### PR DESCRIPTION
@rallyhealth/engineers @sklei2 @htmldoug @rcmurphy 

This will publish Scala 2.12 and Scala 2.13.0-M4 support for scalacheck-ops and will be released as 2.2.0

I've tested the sbt settings locally this time to make sure I'm ready for the release. This is needed to upgrade play-json-ops.