### PR TITLE
Add getOrThrowPure to prepare for getOrThrow in the next major version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 // Aggregate root project settings only
 name := "scalacheck-ops-root"
 
-ThisBuild / gitVersioningSnapshotLowerBound := "2.4.0"
+ThisBuild / gitVersioningSnapshotLowerBound := "2.5.0"
 
 ThisBuild / organization := "com.rallyhealth"
 ThisBuild / organizationName := "Rally Health"
@@ -78,7 +78,7 @@ def coreProject(srcPath: File, scalaCheckVersion: String): Project = {
 
 lazy val `core_1-12` = coreProject(file("core_1-12"), ScalaCheck_1_12)
   .settings(
-    semVerEnforceAfterVersion := Some("2.4.1"),
+    semVerEnforceAfterVersion := Some("2.5.1"),
   )
 lazy val `core_1-13` = coreProject(file("core"), ScalaCheck_1_13)
 lazy val `core_1-14` = coreProject(file("core"), ScalaCheck_1_14)

--- a/core/src/main/scala/org/scalacheck/ops/GenOrThrow.scala
+++ b/core/src/main/scala/org/scalacheck/ops/GenOrThrow.scala
@@ -68,10 +68,30 @@ class GenOrThrow[T: ClassTag](val gen: Gen[T]) {
    * @throws EmptyGenSampleException when samples cannot be generated after a default number of attempts
    */
   @deprecated("The meaning of this method will change in the next major version. " +
-    "If you need a random sample on each call, you should use .randomOrThrow() instead",
+    "If you need a random sample on each call, you should use .getOrThrowPure or .randomOrThrow() instead",
     "2.3.0")
   def getOrThrow: T = getOrThrow(GenConfig.default.withSeed(Seed.random()))
 
+  /**
+    * Get the next instance of this generate with the given configuration.
+    *
+    * @note this is a stateless function and calling this method with
+    *       the same config will always produce the same result.
+    *
+    * @note This is the syntax that will replace the parameterless
+    *       [[getOrThrow]] in the next major version.
+    */
+  def getOrThrowPure(implicit c: GenConfig): T = getOrThrow(c)
+
+  /**
+    * Get a random element from this generator using the default seed.
+    * Generators can run out of samples and will return an empty result.
+    *
+    * Typically this will be the result of bad Gen Parameters or having too many
+    * suchThat() restrictions that reduce the sample size to 0.
+    *
+    * @throws EmptyGenSampleException when samples cannot be generated after a default number of attempts
+    */
   def randomOrThrow()(implicit c: GenConfig = GenConfig.default): T = {
     getOrThrow(c.withSeed(Seed.random()))
   }

--- a/core/src/test/scala/org/scalacheck/ops/GenOrThrowSpec.scala
+++ b/core/src/test/scala/org/scalacheck/ops/GenOrThrowSpec.scala
@@ -88,6 +88,12 @@ class GenOrThrowSpec extends FreeSpec
 
   generatesTheSameValueWhenCalledTwice("getOrThrow (given the same Seed)", _.getOrThrow(Seed(0)))
 
+  generatesTheSameValueWhenCalledTwice("getOrThrowPure", _.getOrThrowPure)
+  throwsAnErrorWhenFiltered(
+    "getOrThrowPure",
+    implicit c => _.getOrThrowPure
+  )
+
   generatesUniqueRandomValues("randomOrThrow", _.randomOrThrow())
   throwsAnErrorWhenFiltered(
     "randomOrThrow()",


### PR DESCRIPTION
- Add a `.getOrThrowPure` that takes a config.
  This can be deprecated in favor of `.getOrThrow` in the next major version when that method is made pure.
- Add missing documentation for `.randomOrThrow()`