### PR TITLE
Fix LocalDate generators, add tests

### DIFF
--- a/joda/src/test/scala/org/scalacheck/ops/time/joda/JodaLocalDateGeneratorsSpec.scala
+++ b/joda/src/test/scala/org/scalacheck/ops/time/joda/JodaLocalDateGeneratorsSpec.scala
@@ -1,0 +1,22 @@
+package org.scalacheck.ops.time.joda
+
+import org.joda.time.{LocalDate, LocalDateTime}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen.chooseNum
+import org.scalacheck.ops.time.GenericDateTimeGeneratorsSpec
+import org.scalacheck.ops.time.joda.ChronologyOps.fromChronology
+
+import scala.reflect.ClassTag
+
+final class JodaLocalDateGeneratorsSpec extends GenericDateTimeGeneratorsSpec(JodaLocalDateGenerators) {
+
+  override protected val arbInstantType: Arbitrary[LocalDate] = {
+    val margin = JodaLocalDateGenerators.defaultRange.toPeriod.plusDays(1) // so +/- margin doesn't put us out of range
+    val chronology = JodaLocalDateGenerators.defaultParams
+    val minMillis = chronology.minLocalDateTime.withPeriodAdded(margin, 1).toDate.getTime
+    val maxMillis = chronology.maxLocalDateTime.withPeriodAdded(margin, -1).toDate.getTime
+    Arbitrary(chooseNum(minMillis, maxMillis).flatMap(new LocalDateTime(_, chronology).toLocalDate))
+  }
+  override protected val clsTagInstantType: ClassTag[LocalDate] = implicitly[ClassTag[LocalDate]]
+  override protected val orderingInstantType: Ordering[LocalDate] = Ordering.fromLessThan(_.compareTo(_) < 0)
+}


### PR DESCRIPTION
Although this `LocalDate` generator has not changed since 2018, it seems to be completely defective. I encountered the issue as activate-eligibility used version 2.1, which (I guess) worked, but then upgrading to a new version of lib-activate-commons pushes it to use 2.5 which does not work. 

There were tests to validate LocalDateTime behavior, but no tests for LocalDate. I added the tests, validated the old code did not pass the tests, and validated the new code does pass the tests.

@jeffmay