### PR TITLE
Turn off publishing the root project properly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 // TODO: Remove this after it is no longer needed for checking binary compatibility
 ThisBuild / resolvers += Resolver.bintrayRepo("rallyhealth", "maven")
 
-developers := List(
+ThisBuild / developers := List(
   Developer(id = "jeffmay", name = "Jeff May", email = "jeff.n.may@gmail.com", url = url("https://github.com/jeffmay")),
 )
 
@@ -25,8 +25,7 @@ developers := List(
 mimaFailOnNoPrevious := false
 
 // don't publish the aggregate root project
-skip / publish := true
-skip / publishLocal := true
+publish / skip := true
 
 def commonProject(id: String, artifact: String, path: String): Project = {
   Project(id, file(path)).settings(


### PR DESCRIPTION
Looks like the root project is being published: https://search.maven.org/artifact/com.rallyhealth/scalacheck-ops-root_2.13/2.6.0/jar

I looked at this feature (from https://github.com/sbt/sbt/pull/3380) and it looks like I had the scope wrong.

I also made sure that the other settings are applied across all subprojects.