### PR TITLE
Publish to legacy 1.5.0 version to Sonatype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 
 # sbt specific
+.bsp
 .cache
 .history
 .lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,26 @@
 language: scala
 scala:
-  - 2.11.8
-  - 2.10.6
+  - 2.13.5
 jdk:
-  - oraclejdk8
+  - openjdk8
+
+before_script:
+  # Download sbt because Travis can't find it automatically :(
+  - mkdir -p $HOME/.sbt/launchers/1.5.0/
+  - curl -L -o $HOME/.sbt/launchers/1.5.0/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.0/sbt-launch-1.5.0.jar
 
 script:
-  - sbt clean coverage test coverageReport
-after_success:
-  - sbt 'project core_1-12' coveralls
+  - sbt clean +test
 
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+# Avoid unnecessary cache updates
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
 
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
-
+    - $HOME/.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,102 +1,81 @@
+// Aggregate root project settings only
+name := "scalacheck-ops-root"
+ThisBuild / scalaVersion := "2.11.8"
 
-val commonRootSettings = Seq(
-  name := "scalacheck-ops",
-  organization := "me.jeffmay",
-  organizationName := "Jeff May",
-  version := "1.5.0",
+val ScalaCheck_1_12 = "1.12.5"
+val ScalaCheck_1_13 = "1.13.2"
 
-  // scala version for root project
-  scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.11.8", "2.10.6"),
+val ScalaTest_2 = "2.2.6"
+val ScalaTest_3 = "3.0.0"
 
-  licenses += ("Apache-2.0", url("http://opensource.org/licenses/apache-2.0"))
+ThisBuild / organization := "com.rallyhealth"
+ThisBuild / organizationName := "Rally Health"
+
+ThisBuild / versionScheme := Some("early-semver")
+ThisBuild / licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
+
+// reload sbt when the build files change
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
+developers := List(
+  Developer(id = "jeffmay", name = "Jeff May", email = "jeff.n.may@gmail.com", url = url("https://github.com/jeffmay")),
 )
 
-lazy val root = (project in file("."))
-  .settings(commonRootSettings)
-  .settings(
-    name := "scalacheck-ops-root",
-    // don't publish the surrounding multi-project root
-    publish := {},
-    publishLocal := {}
+// don't look for previous versions any project, this is the oldest legacy version we support
+ThisBuild / mimaFailOnNoPrevious := false
+
+// don't publish the aggregate root project
+publish / skip := true
+
+def commonProject(id: String, artifact: String, path: String): Project = {
+  Project(id, file(path)).settings(
+    name := artifact,
+
+    scalacOptions := {
+      // the deprecation:false flag is only supported by scala >= 2.11.3, but needed for scala >= 2.11.0 to avoid warnings
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, scalaMinor)) if scalaMinor >= 11 =>
+          // For scala versions >= 2.11.3
+          Seq("-Xfatal-warnings", "-deprecation:false")
+        case Some((2, scalaMinor)) if scalaMinor < 11 =>
+          // For scala versions 2.10.x
+          Seq("-Xfatal-warnings")
+      }
+    } ++ Seq(
+      "-feature",
+      "-Xlint",
+      "-Ywarn-dead-code",
+      "-encoding", "UTF-8"
+    ),
+
+    // show full stack traces in test failures
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
+
+    // disable compilation of ScalaDocs, since this always breaks on links and isn't as helpful as source
+    Compile / doc / sources := Seq.empty,
+
+    // disable publishing empty ScalaDocs
+    Compile / packageDoc / publishArtifact := false
   )
-  .aggregate(`core_1-12`, `core_1-13`)
-
-// the version of scalacheck, all cross-compiled settings are derived from this setting
-lazy val scalacheckVersion = settingKey[String]("version of scalacheck (all cross-compiled settings are derived from this setting)")
-
-// using scalatest version 3.0.0 should be no problem
-lazy val scalatestVersion = settingKey[String]("version of scalatest")
-
-/**
-  * Choose one value or another based on the version of scalacheck.
-  */
-def basedOnVersion[T](version: String, old: T, latest: T): T = {
-  if (version startsWith "1.12.") old else latest
 }
 
-val commonSettings = commonRootSettings ++ Seq(
-
-  // scalatest 2.2.6 pulls in scalacheck and it only works with 1.12.5
-  // if you want to pull in the latest version, you should be fine to pull in scalacheck 1.13.x
-  scalatestVersion := basedOnVersion(scalacheckVersion.value, "2.2.6", "3.0.0"),
-
-  scalacOptions := {
-    // the deprecation:false flag is only supported by scala >= 2.11.3, but needed for scala >= 2.11.0 to avoid warnings
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, scalaMinor)) if scalaMinor >= 11 =>
-        // For scala versions >= 2.11.3
-        Seq("-Xfatal-warnings", "-deprecation:false")
-      case Some((2, scalaMinor)) if scalaMinor < 11 =>
-        // For scala versions 2.10.x
-        Seq("-Xfatal-warnings")
-    }
-  } ++ Seq(
-    "-feature",
-    "-Xlint",
-    "-Ywarn-dead-code",
-    "-encoding", "UTF-8"
-  ),
-
-  libraryDependencies ++= Seq(
-    // pull in the specified version of scalacheck
-    "org.scalacheck" %% "scalacheck" % scalacheckVersion.value,
-    // scalatest 2.2.6 pulls in scalacheck 1.12.5 so it only works with 1.12.5
-    "org.scalatest" %% "scalatest" % scalatestVersion.value % Test
-  ),
-
-  // show full stack traces in test failures ()
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
-
-  // force scala version
-  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
-
-  // disable compilation of ScalaDocs, since this always breaks on links and isn't as helpful as source
-  sources in(Compile, doc) := Seq.empty,
-
-  // disable publishing empty ScalaDocs
-  publishArtifact in (Compile, packageDoc) := false
-)
-
-val coreSettings = commonSettings ++ Seq(
-  sourceDirectory := file("core/src").getAbsoluteFile,
-  libraryDependencies ++= Seq(
-    "org.joda" % "joda-convert" % "1.8",
-    "joda-time" % "joda-time" % "2.9.4"
+def coreProject(scalaCheckVersion: String, scalatestVersion: String): Project = {
+  val (path, artifactName) = scalaCheckVersion match {
+    case ScalaCheck_1_12 => ("core_1-12", "scalacheck-ops_1-12")
+    case ScalaCheck_1_13 => ("core_1-13", "scalacheck-ops_1-13")
+  }
+  commonProject(artifactName, artifactName, path).settings(
+    crossScalaVersions := Seq("2.11.8", "2.10.6"),
+    sourceDirectory := file("core/src").getAbsoluteFile,
+    libraryDependencies ++= Seq(
+      "org.joda" % "joda-convert" % "1.8",
+      "joda-time" % "joda-time" % "2.9.4",
+      "org.scalacheck" %% "scalacheck" % scalaCheckVersion,
+      "org.scalatest" %% "scalatest" % scalatestVersion % Test
+    )
   )
-)
+}
 
-lazy val `core_1-12` = (project in file("core"))
-  .settings(coreSettings: _*)
-  .settings(
-    name := "scalacheck-ops",
-    scalacheckVersion := "1.12.5"
-  )
-
-lazy val `core_1-13` = (project in file("core_1.13"))
-  .settings(coreSettings: _*)
-  .settings(
-    name := "scalacheck-ops_1.13",
-    scalacheckVersion := "1.13.2"
-  )
+lazy val `core_1-12` = coreProject(ScalaCheck_1_12, ScalaTest_2)
+lazy val `core_1-13` = coreProject(ScalaCheck_1_13, ScalaTest_3)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,4 @@
-resolvers += Classpaths.sbtPluginReleases
-
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-    Resolver.ivyStylePatterns)
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
-
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
-
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,22 @@
+// Your profile name of the sonatype account. The default is the same with the organization value
+sonatypeProfileName := "com.rallyhealth"
+
+// To sync with Maven central, you need to supply the following information:
+publishMavenStyle := true
+
+// publish to Maven Central
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+ThisBuild / publishTo := Some {
+  if (isSnapshot.value)
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/snapshots"))
+  else
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/releases"))
+}
+
+// add SNAPSHOT to non-release versions so they are not published to the main repo
+ThisBuild / dynverSonatypeSnapshots := true
+// Use '-' instead of '+' for simpler snapshot URLs
+ThisBuild / dynverSeparator := "-"
+
+import xerial.sbt.Sonatype.GitHubHosting
+sonatypeProjectHosting := Some(GitHubHosting("rallyhealth", "scalacheck-ops", "jeff.n.may@gmail.com"))


### PR DESCRIPTION
@jiwanpokharel was having issues with this artifact after Bintray was shut down. We tried investigating various combinations of versions to avoid major breaking changes on downstream dependencies but could not find a combination of cached versions that would work.

This is a one-time legacy import into Sonatype for this really old version of artifacts. This branch will not be supported beyond this stop-gap fix. Any upgrade from here will need to use a version >= 2.6.0