### PR TITLE
Add GenFromConfigImplicits and TruncatedJavaTimeImplicits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: scala
 scala:
-  - 2.13.5
+  - 2.13.6
 jdk:
   - openjdk8
   - openjdk11
 
 before_script:
   # Download sbt because Travis can't find it automatically :(
-  - mkdir -p $HOME/.sbt/launchers/1.5.0/
-  - curl -L -o $HOME/.sbt/launchers/1.5.0/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.0/sbt-launch-1.5.0.jar
+  - mkdir -p $HOME/.sbt/launchers/1.5.3/
+  - curl -L -o $HOME/.sbt/launchers/1.5.3/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.3/sbt-launch-1.5.3.jar
 
 script:
   - sbt clean coverage +test coverageAggregate

--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,7 @@ def coreProject(srcPath: File, testPath: File, scalaCheckVersion: String): Proje
     Compile / sourceDirectory := (srcPath / "src" / "main").getAbsoluteFile,
     Test / sourceDirectory := (testPath / "src" / "test").getAbsoluteFile,
     libraryDependencies ++= Seq(
+      izumiReflect,
       scalaCheck(scalaCheckVersion),
       tagging,
     ) ++ {

--- a/core-1-13-test/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
+++ b/core-1-13-test/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 
 import scala.util.Try
 
-class GenOpsSpec extends FlatSpec
-  with ScalaCheckImplicits {
+class GenOpsSpec extends FlatSpec {
 
   private def genDigits: Gen[Int] = Gen.choose(0, 100)
 
@@ -24,8 +23,8 @@ class GenOpsSpec extends FlatSpec
   it should "generate the same samples when called twice with the same seed" in {
     val gen = Gen.setOf(Gen.choose(0, 1))
     val seed = Seed(1)
-    val a = gen.getOrThrow(seed)
-    val b = gen.getOrThrow(seed)
+    val a = gen.valueFor(seed)
+    val b = gen.valueFor(seed)
     assert(a == b)
   }
 
@@ -53,8 +52,8 @@ class GenOpsSpec extends FlatSpec
     val collectNegative = Gen.collect(Gen.chooseNum(1, 10)) {
       case x if x < 0 => x
     }
-    an [EmptyGenSampleException[Int]] shouldBe thrownBy {
-      collectNegative.randomOrThrow()
+    an [GenExceededRetryLimit] shouldBe thrownBy {
+      collectNegative.nextRandom()
     }
   }
 
@@ -71,8 +70,8 @@ class GenOpsSpec extends FlatSpec
     val n = 10
     val gen = Gen.setOfN(n, genDigits)
     val seed = Seed(n)
-    val a = gen.getOrThrow(seed)
-    val b = gen.getOrThrow(seed)
+    val a = gen.valueFor(seed)
+    val b = gen.valueFor(seed)
     assert(a == b)
   }
 

--- a/core/src/main/scala/org/scalacheck/ops/Exceptions.scala
+++ b/core/src/main/scala/org/scalacheck/ops/Exceptions.scala
@@ -7,9 +7,27 @@ import scala.reflect.{ClassTag, classTag}
 /**
  * An exception thrown when a value cannot be pulled out from the Gen.sample method after a number of tries.
  */
-class EmptyGenSampleException[T : ClassTag](val generator: Gen[T], val attempts: Long)
+@deprecated("Use GenExceededRetryLimit instead.", "2.7.0")
+class EmptyGenSampleException[T : ClassTag](val generator: Gen[T], attempts: Long)
+  extends GenExceededRetryLimit(classTag[T].runtimeClass.getName, attempts)
+
+/**
+ * An exception thrown when a value cannot be pulled out from the Gen.sample method after a number of tries.
+ *
+ * TODO: Convert to final class in next major version.
+ */
+sealed class GenExceededRetryLimit protected (val typeName: String, val attempts: Long)
   extends Exception(
-    s"Cannot generate an instance of ${classTag[T].runtimeClass.getName} after $attempts attempts to " +
+    s"Cannot generate an instance of $typeName after $attempts attempts to " +
       "get an unfiltered sample from a ScalaCheck Gen.  " +
       "Try adjusting the Gen.Parameters or loosening the restrictions to prevent exhausting the samples."
   )
+
+object GenExceededRetryLimit {
+
+  def apply(typeName: String, attempts: Long): GenExceededRetryLimit =
+    new GenExceededRetryLimit(typeName, attempts)
+
+  def fromClassTag[T : ClassTag](attempts: Long): GenExceededRetryLimit =
+    new GenExceededRetryLimit(classTag[T].runtimeClass.getName, attempts)
+}

--- a/core/src/main/scala/org/scalacheck/ops/GenFromConfig.scala
+++ b/core/src/main/scala/org/scalacheck/ops/GenFromConfig.scala
@@ -1,0 +1,150 @@
+package org.scalacheck.ops
+
+import org.scalacheck.Gen
+import org.scalacheck.Gen.RetrievalError
+import org.scalacheck.rng.Seed
+
+import scala.util.Random
+
+final class GenFromConfig[T](gen: Gen[T], config: GenConfig, typeName: String) {
+
+  private[this] def headFromConfig(c: GenConfig): T = {
+    try gen.pureApply(c.params, c.seed, c.retries)
+    catch {
+      case _: RetrievalError =>
+        // attempts exhausted, return failure
+        throw GenExceededRetryLimit(typeName, c.retries)
+    }
+  }
+
+  private[this] def iteratorFromConfig(seed: Seed): Iterator[T] = {
+    var s = seed
+    Iterator.continually {
+      val res = headFromConfig(config.withSeed(s))
+      s = s.next
+      res
+    }
+  }
+
+  /**
+   * Get the first instance of this generator with the given configuration.
+   *
+   * @note this is a stateless function and calling this method with
+   *       the same config will always produce the same result.
+   */
+  @throws[GenExceededRetryLimit](
+    "When the number of attempts to generate a valid sample is exhausted because " +
+      "the filters on this generator are too restrictive.")
+  def head: T = headFromConfig(config)
+
+  /**
+   * Modify the captured [[GenConfig]] using the given function.
+   */
+  def configured(fn: GenConfig => GenConfig): GenFromConfig[T] = new GenFromConfig(gen, fn(config), typeName)
+
+  /**
+   * Effectively shorthand for `.configured(_.withSeed(seed)).head`.
+   */
+  @throws[GenExceededRetryLimit](
+    "When the number of attempts to generate a valid sample is exhausted because " +
+      "the filters on this generator are too restrictive.")
+  def valueFor(seed: Seed): T = headFromConfig(config.withSeed(seed))
+
+  /**
+   * An iterator made by attempting to find each next sample after the given number of retries.
+   *
+   * @note This uses the new pureApply feature only available in ScalaCheck versions >=1.14.x
+   *
+   * @return An iterator that will generate from the given starting seed
+   */
+  @throws[GenExceededRetryLimit](
+    "When the number of attempts to generate a valid sample is exhausted because " +
+      "the filters on this generator are too restrictive.")
+  def iterator: Iterator[T] = iteratorFromConfig(config.seed)
+
+  /**
+   * Get a random element from this generator using the default seed.
+   *
+   * Generators can run out of samples and return empty results. Typically,
+   * this will be the result of bad Gen Parameters or having too many
+   * suchThat() restrictions that make it difficult to find the next sample.
+   */
+  @throws[GenExceededRetryLimit](
+    "When the number of attempts to generate a valid sample is exhausted because " +
+      "the filters on this generator are too restrictive.")
+  def nextRandom(rng: Random = Random): T = {
+    headFromConfig(config.withSeed(config.seed.reseed(rng.nextLong())))
+  }
+
+  /**
+   * Effectively the same as calling [[nextRandom()]] with [[Iterator.continually]], except that
+   * the given [[Random]] number generator is only used to generate the first seed and all subsequent
+   * iterations are produced from [[Seed.next]].
+   *
+   * @note If you want to provide a consistent [[Seed]], you should use [[configured]]
+   *       to set [[GenConfig.withSeed]] and then call [[iterator]].
+   *
+   * @param rng the random number generator used to initialize the seed.
+   */
+  @throws[GenExceededRetryLimit](
+    "When the number of attempts to generate a valid sample is exhausted because " +
+      "the filters on this generator are too restrictive.")
+  def nextRandomIterator(rng: Random = Random): Iterator[T] = iteratorFromConfig(Seed(rng.nextLong()))
+
+  // Keeping the following methods around to keep source compatibility with 2.6.0 and avoid some of the pain
+  // of pulling in versions >= 2.7.0
+
+  /**
+   * An iterator made by [[Iterator.continually]] calling [[Gen.sample]].
+   *
+   * @note If the generator has filters, then this method could return None a lot. If you want a
+   *       safe way to filter the Nones, see [[iterator]]
+   *
+   * @note This will use a random seed for each sample. If you want to get the same iterator from
+   *       the same seed, you would have to use [[iterator]] and handle the possible.
+   *
+   * @return An iterator of Options which are None if the generator's filters ruled out the sample.
+   */
+  def sampleIterator: Iterator[Option[T]] = Iterator continually gen.sample
+
+  /**
+   * Converts this generator to an [[Iterator]] in the obvious (but potentially dangerous) way.
+   *
+   * @note This pulls an item from the generator one at a time, however, if the generator has too
+   * many restrictive filters, this can result in an infinite loop.
+   *
+   * @see [[iterator]] for a safer, bounded alternative.
+   *
+   * @return An [[Iterator]] that returns only the defined samples.
+   */
+  @deprecated("This is generally a bad idea and is easy enough to inline. It will be removed in the next major version.", "2.7.0")
+  def toUnboundedIterator: Iterator[T] = sampleIterator collect { case Some(x) => x }
+
+  /**
+   * Get a random element from this generator using the default seed.
+   *
+   * Generators can run out of samples and return empty results. Typically,
+   * this will be the result of bad Gen Parameters or having too many
+   * suchThat() restrictions that make it difficult to find the next sample.
+   */
+  @deprecated(
+    "If you need a random sample on each call, use .nextRandom()\n" +
+      "If you want a stateless function, use .head\n" +
+      "If you want to pass a specific Seed, use .configured(_.withSeed(seed)).head",
+    "2.3.0")
+  @throws[GenExceededRetryLimit](
+    "When the number of attempts to generate a valid sample is exhausted because " +
+      "the filters on this generator are too restrictive.")
+  def getOrThrow: T = headFromConfig(GenConfig.default.withSeed(Seed.random()))
+
+  /**
+   * @see [[head]]
+   */
+  @deprecated("Use .head instead. This method is contradictory " +
+    "(throwing an exception makes the function partially undefined and thus impure) and verbose " +
+    "(this has very similar semantics to the familiar .head method on Scala collections)", "2.7.0")
+  @throws[GenExceededRetryLimit](
+    "When the number of attempts to generate a valid sample is exhausted because " +
+      "the filters on this generator are too restrictive.")
+  def getOrThrowPure: T = head
+}

--- a/core/src/main/scala/org/scalacheck/ops/GenOps.scala
+++ b/core/src/main/scala/org/scalacheck/ops/GenOps.scala
@@ -37,6 +37,7 @@ object GenOps {
     } yield new String(arr)
   }
 
+  // TODO: Switch this to TypeName in the next major version
   def setOfN[T: ClassTag](size: Int, maxFailures: Int, tGen: Gen[T]): Gen[Set[T]] = {
     for {
       _ <- Gen.const(tGen)
@@ -44,7 +45,7 @@ object GenOps {
       var failures = 0
       var total = 0
       val set = mutable.Set.empty[T]
-      val iter = tGen.toIterator
+      val iter = new GenFromConfig(tGen, GenConfig.default, classTag[T].runtimeClass.getName).iterator
       while(failures < maxFailures && total < size) {
         if (set.add(iter.next())) {
           total += 1

--- a/core/src/main/scala/org/scalacheck/ops/GenOrThrow.scala
+++ b/core/src/main/scala/org/scalacheck/ops/GenOrThrow.scala
@@ -13,15 +13,14 @@ import scala.util.Try
  * @param gen a generator of some kind
  * @tparam T the type of value produced by the generator
  */
+@deprecated("Use GenFromConfig instead. This class requires a ClassTag and is not as reusable as GenFromConfig. " +
+  "It will be removed in the next major version.", "2.7.0")
 class GenOrThrow[T: ClassTag](val gen: Gen[T]) {
   self =>
 
   /**
-   * An iterator made by attempting to find each next sample after the given number of retries.
-   *
-   * @note This uses the new pureApply feature only available in ScalaCheck versions >=1.14.x
-   *
-   * @return An iterator that will generate from the given starting seed
+   * Same as [[GenFromConfig.iterator]] except throws an [[EmptyGenSampleException]]
+   * instead of [[GenExceededRetryLimit]]
    *
    * @throws EmptyGenSampleException when samples cannot be generated after the given number of attempts
    */
@@ -46,8 +45,9 @@ class GenOrThrow[T: ClassTag](val gen: Gen[T]) {
   }
 
   /**
-   * Get the next element from this generator using the given seed and default size and number of retries.
+   * Same as [[GenFromConfig.getOrThrow]] except throws an [[EmptyGenSampleException]]
    */
+  @deprecated("Use .getConfigured(_.withSeed(seed)) instead.", "2.7.0")
   def getOrThrow(seed: Seed): T = getOrThrow(GenConfig.default.withSeed(seed))
 
   /**
@@ -59,39 +59,27 @@ class GenOrThrow[T: ClassTag](val gen: Gen[T]) {
   def getOrThrow(attempts: Int): T = randomOrThrow()(GenConfig.default.withRetries(attempts))
 
   /**
-   * Get a random element from this generator using the default seed.
-   *
-   * Generators can run out of samples and return empty results. Typically,
-   * this will be the result of bad Gen Parameters or having too many
-   * suchThat() restrictions that make it difficult to find the next sample.
+   * Same as [[GenFromConfig.getOrThrow]] except throws a [[EmptyGenSampleException]]
+   * instead of [[GenExceededRetryLimit]]
    *
    * @throws EmptyGenSampleException when samples cannot be generated after a default number of attempts
    */
-  @deprecated("The meaning of this method will change in the next major version. " +
-    "If you need a random sample on each call, you should use .getOrThrowPure or .randomOrThrow() instead",
-    "2.3.0")
+  @deprecated("If you need a random sample on each call, use .nextRandom() -- " +
+    "otherwise, if you want a stateless function, use .head instead.", "2.3.0")
   def getOrThrow: T = getOrThrow(GenConfig.default.withSeed(Seed.random()))
 
   /**
-    * Get the next instance of this generate with the given configuration.
-    *
-    * @note this is a stateless function and calling this method with
-    *       the same config will always produce the same result.
-    *
-    * @note This is the syntax that will replace the parameterless
-    *       [[getOrThrow]] in the next major version.
-    */
+   * @see [[GenFromConfig.head]]
+   */
+  @deprecated("Use .head instead. This method is contradictory " +
+    "(throwing an exception makes the function partially undefined and thus impure) and verbose " +
+    "(this has very similar semantics to the familiar .head method on Scala collections)", "2.7.0")
   def getOrThrowPure(implicit c: GenConfig): T = getOrThrow(c)
 
   /**
-    * Get a random element from this generator using the default seed.
-    * Generators can run out of samples and will return an empty result.
-    *
-    * Typically this will be the result of bad Gen Parameters or having too many
-    * suchThat() restrictions that reduce the sample size to 0.
-    *
-    * @throws EmptyGenSampleException when samples cannot be generated after a default number of attempts
+    * @see [[GenFromConfig.nextRandom]]
     */
+  @deprecated("Use .nextRandom() instead.", "2.7.0")
   def randomOrThrow()(implicit c: GenConfig = GenConfig.default): T = {
     getOrThrow(c.withSeed(Seed.random()))
   }
@@ -103,6 +91,7 @@ class GenOrThrow[T: ClassTag](val gen: Gen[T]) {
   /**
    * Get the next element from this generator using the given seed and default size and number of retries.
    */
+  @deprecated("Use Try(gen.getConfigured(_.withSeed(seed))) instead.", "2.7.0")
   def tryGet(seed: Seed): Try[T] = tryGet(GenConfig.default.withSeed(seed))
 
   /**
@@ -112,36 +101,23 @@ class GenOrThrow[T: ClassTag](val gen: Gen[T]) {
    * @return Either a non-empty sample or a Failure with information about what sample was tried.
    */
   @deprecated("Do not provide the number of retries. This method will be removed in the next major version.", "2.3.0")
-  def tryGet(attempts: Int): Try[T] = Try(gen.randomOrThrow()(GenConfig.default.withRetries(attempts)))
+  def tryGet(attempts: Int): Try[T] = Try(randomOrThrow()(GenConfig.default.withRetries(attempts)))
 
   /**
    * Same as `Try(gen.randomOrThrow())`
    */
-  @deprecated("The meaning of this method will change in the next major version. " +
-    "If you need a random sample on each call, you should use .randomOrThrow() instead",
-    "2.3.0")
-  def tryGet: Try[T] = Try(gen.randomOrThrow())
+  @deprecated("This method will be removed in the next major version", "2.3.0")
+  def tryGet: Try[T] = Try(randomOrThrow())
 
   /**
-   * An iterator made by continuously sampling the generator.
-   *
-   * @note If the generator has filters, then this method could return None a lot. If you want a
-   *       safe way to filter the Nones, see [[toIterator]]
-   *
-   * @return An iterator of Options which are None if the generator's filters ruled out the sample.
+   * Same as [[GenFromConfig.sampleIterator]].
    */
   def sampleIterator: Iterator[Option[T]] = Iterator continually gen.sample
 
   /**
-   * Converts this generator to an [[Iterator]] in the obvious (but potentially dangerous) way.
-   *
-   * @note This pulls an item from the generator one at a time, however, if the generator has too
-   * many restrictive filters, this can result in an infinite loop.
-   *
-   * @see [[toIterator]] for a safer, bounded alternative.
-   *
-   * @return An [[Iterator]] that returns only the defined samples.
+   * Same as [[GenFromConfig.toUnboundedIterator]].
    */
+  @deprecated("This is generally a bad idea and is easy enough to inline. It will be removed in the next major version.", "2.7.0")
   def toUnboundedIterator: Iterator[T] = sampleIterator collect { case Some(x) => x }
 
   /**

--- a/core/src/main/scala/org/scalacheck/ops/ImplicitGenFromConfig.scala
+++ b/core/src/main/scala/org/scalacheck/ops/ImplicitGenFromConfig.scala
@@ -1,0 +1,19 @@
+package org.scalacheck.ops
+
+import org.scalacheck.Gen
+
+trait ImplicitGenFromConfig {
+
+  import scala.language.implicitConversions
+
+  implicit def genFromConfigOps[T](gen: Gen[T])(implicit gc: GenConfig, tn: TypeName[T]): GenFromConfig[T] =
+    new GenFromConfig[T](gen, gc, tn.typeName)
+
+  implicit def genFromConfigBuilder[T](gen: Gen[T]): GenFromConfigBuilder[T] = new GenFromConfigBuilder[T](gen)
+}
+
+final class GenFromConfigBuilder[T](private val gen: Gen[T]) extends AnyVal {
+
+  def getOrFailWithName(typeName: String)(implicit gc: GenConfig): GenFromConfig[T] =
+    new GenFromConfig[T](gen, gc, typeName)
+}

--- a/core/src/main/scala/org/scalacheck/ops/ScalaCheckImplicits.scala
+++ b/core/src/main/scala/org/scalacheck/ops/ScalaCheckImplicits.scala
@@ -1,7 +1,7 @@
 package org.scalacheck.ops
 
 import org.scalacheck.Gen
-import org.scalacheck.ops.time.{ImplicitJavaTimeGenerators, JavaTimeImplicits}
+import org.scalacheck.ops.time.{ImplicitJavaTimeGenerators, JavaTimeImplicits, TruncatedJavaTimeImplicits}
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -10,6 +10,7 @@ trait ScalaCheckImplicits
   extends ArbitraryAsGen
   with ImplicitGenFromConfig
   with JavaTimeImplicits
+  with TruncatedJavaTimeImplicits
   with ImplicitJavaTimeGenerators
   with ShrinkLargeTuples {
 

--- a/core/src/main/scala/org/scalacheck/ops/ScalaCheckImplicits.scala
+++ b/core/src/main/scala/org/scalacheck/ops/ScalaCheckImplicits.scala
@@ -8,6 +8,7 @@ import scala.reflect.ClassTag
 
 trait ScalaCheckImplicits
   extends ArbitraryAsGen
+  with ImplicitGenFromConfig
   with JavaTimeImplicits
   with ImplicitJavaTimeGenerators
   with ShrinkLargeTuples {
@@ -16,6 +17,8 @@ trait ScalaCheckImplicits
 
   implicit def genObjectToGenOps(gen: Gen.type): GenOps.type = GenOps
 
-  implicit def genToGenOrThrow[T: ClassTag](generator: Gen[T]): GenOrThrow[T] = new GenOrThrow[T](generator)
+  // No longer an implicit, but leaving this here for binary compatibility
+  @deprecated("Use implicit conversion to GenFromConfig instead.", "2.7.0")
+  def genToGenOrThrow[T: ClassTag](generator: Gen[T]): GenOrThrow[T] = new GenOrThrow[T](generator)
 
 }

--- a/core/src/main/scala/org/scalacheck/ops/ScalaCheckImplicits.scala
+++ b/core/src/main/scala/org/scalacheck/ops/ScalaCheckImplicits.scala
@@ -1,16 +1,16 @@
 package org.scalacheck.ops
 
 import org.scalacheck.Gen
-import org.scalacheck.ops.time.{ImplicitJavaTimeGenerators, JavaTimeImplicits, TruncatedJavaTimeImplicits}
+import org.scalacheck.ops.time.{ImplicitJavaTimeGenerators, JavaTimeImplicits}
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
+// TODO: Move everything to the package object to prevent inheritance here. It is bad for binary compatibility.
+@deprecated("Don't extend ScalaCheckImplicits. Import from org.scalacheck.ops._ instead.", "2.7.0")
 trait ScalaCheckImplicits
   extends ArbitraryAsGen
-  with ImplicitGenFromConfig
   with JavaTimeImplicits
-  with TruncatedJavaTimeImplicits
   with ImplicitJavaTimeGenerators
   with ShrinkLargeTuples {
 

--- a/core/src/main/scala/org/scalacheck/ops/TypeName.scala
+++ b/core/src/main/scala/org/scalacheck/ops/TypeName.scala
@@ -1,0 +1,29 @@
+package org.scalacheck.ops
+
+import izumi.reflect.Tag
+
+import scala.annotation.implicitNotFound
+import scala.reflect.ClassTag
+
+@implicitNotFound(
+  "Could not grab the type name of ${T} at compile-time... except for printing this error message (go figure). " +
+    "This means that neither a ClassTag nor izumi.reflect.Tag could not be summoned for this type.")
+final class TypeName[T] private (val typeName: String)
+
+object TypeName extends LowPriorityTypeName {
+
+  def fromIzumiTag[T: Tag]: TypeName[T] = new TypeName[T](Tag[T].tag.longName)
+
+  def fromClassTag[T: ClassTag]: TypeName[T] = new TypeName[T](implicitly[ClassTag[T]].runtimeClass.getName)
+}
+
+sealed trait LowPriorityTypeName extends LowerPriorityTypeName {
+
+  implicit def typeNameFromClassTag[T : ClassTag]: TypeName[T] = TypeName.fromClassTag
+}
+
+sealed trait LowerPriorityTypeName {
+
+  // TODO: Use https://blog.7mind.io/no-more-orphans.html trick to avoid transitive dependency on izumi?
+  implicit def typeNameFromIzumiTag[T : Tag]: TypeName[T] = TypeName.fromIzumiTag
+}

--- a/core/src/main/scala/org/scalacheck/ops/TypeName.scala
+++ b/core/src/main/scala/org/scalacheck/ops/TypeName.scala
@@ -6,7 +6,9 @@ import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
 
 @implicitNotFound(
-  "Could not grab the type name of ${T} at compile-time... except for printing this error message (go figure). " +
+  // Splitting the $ and {T} to avoid a false missing interpolator compiler warning
+  // see https://stackoverflow.com/questions/39401213/disable-false-warning-possible-missing-interpolator
+  "Could not grab the type name of $" + "{T} at compile-time... except for printing this error message (go figure). " +
     "This means that neither a ClassTag nor izumi.reflect.Tag could not be summoned for this type.")
 final class TypeName[T] private (val typeName: String)
 

--- a/core/src/main/scala/org/scalacheck/ops/package.scala
+++ b/core/src/main/scala/org/scalacheck/ops/package.scala
@@ -1,7 +1,12 @@
 package org.scalacheck
 
+import org.scalacheck.ops.time.TruncatedJavaTimeImplicits
+
 /**
   * @note if you would like joda DateTime implicits to be included (as they were in past versions of scalacheck-ops),
   *       you will need to include the scalacheck-ops-joda library and import org.scalacheck.ops.time.joda._.
   */
-package object ops extends ScalaCheckImplicits
+package object ops
+  extends ScalaCheckImplicits
+    with ImplicitGenFromConfig
+    with TruncatedJavaTimeImplicits

--- a/core/src/main/scala/org/scalacheck/ops/time/TruncatedJavaTimeImplicits.scala
+++ b/core/src/main/scala/org/scalacheck/ops/time/TruncatedJavaTimeImplicits.scala
@@ -1,0 +1,27 @@
+package org.scalacheck.ops.time
+
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, LocalDateTime}
+
+import org.scalacheck.Gen
+
+trait TruncatedJavaTimeImplicits {
+  import scala.language.implicitConversions
+
+  implicit def truncatedInstantGen(instantGen: Gen[Instant]): TruncatedInstantGen = {
+    new TruncatedInstantGen(instantGen)
+  }
+
+  implicit def truncatedLocalDateTimeGen(localDateTimeGen: Gen[LocalDateTime]): TruncatedLocalDateTimeGen = {
+    new TruncatedLocalDateTimeGen(localDateTimeGen)
+  }
+}
+
+class TruncatedInstantGen(val instantGen: Gen[Instant]) extends AnyVal {
+  def truncatedToMillis: Gen[Instant] = instantGen.map(_.truncatedTo(ChronoUnit.MILLIS))
+}
+
+class TruncatedLocalDateTimeGen(val localDateTimeGen: Gen[LocalDateTime]) extends AnyVal {
+  def truncatedToMillis: Gen[LocalDateTime] = localDateTimeGen.map(_.truncatedTo(ChronoUnit.MILLIS))
+  def truncatedTo(unit: ChronoUnit): Gen[LocalDateTime] = localDateTimeGen.map(_.truncatedTo(unit))
+}

--- a/core/src/test/scala/org/scalacheck/ops/GenFromConfigSpec.scala
+++ b/core/src/test/scala/org/scalacheck/ops/GenFromConfigSpec.scala
@@ -3,10 +3,9 @@ package org.scalacheck.ops
 import java.util.UUID
 import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class GenOrThrowSpec extends FreeSpec
-  with ScalaCheckImplicits {
+class GenFromConfigSpec extends AnyFreeSpec {
 
   type MethodCall[A] = Gen[A] => Any
 
@@ -76,63 +75,46 @@ class GenOrThrowSpec extends FreeSpec
     }
   }
 
-  generatesUniqueRandomValues("getOrThrow", gen => new GenOrThrow(gen).getOrThrow)
+  generatesTheSameValueWhenCalledTwice("head", _.head)
+  throwsAnErrorWhenFiltered(
+    "head",
+    implicit c => _.head,
+    minRetryLimit = 100
+  )
+
+  generatesTheSameValueWhenCalledTwice("valueFor(Seed(10))", _.valueFor(Seed(10)))
+  throwsAnErrorWhenFiltered(
+    "valueFor(Seed(10))",
+    implicit c => _.valueFor(Seed(10)),
+    minRetryLimit = 100
+  )
+
+  generatesUniqueRandomValues("nextRandom()", _.nextRandom())
+  throwsAnErrorWhenFiltered(
+    "nextRandom()",
+    implicit c => _.nextRandom()
+  )
+
+  // Coverage for deprecated method placeholders
+
+  generatesUniqueRandomValues("getOrThrow", _.getOrThrow)
   throwsAnErrorWhenFiltered(
     "getOrThrow",
-    _ => gen => new GenOrThrow(gen).getOrThrow,
+    _ => _.getOrThrow,
     minRetryLimit = 100
   )
 
-  generatesTheSameValueWhenCalledTwice("getOrThrow (given the same Seed)", gen => new GenOrThrow(gen).getOrThrow(Seed(0)))
-
-  generatesTheSameValueWhenCalledTwice("getOrThrowPure", gen => new GenOrThrow(gen).getOrThrowPure)
-  throwsAnErrorWhenFiltered(
-    "getOrThrowPure",
-    implicit c => _.getOrThrowPure
-  )
-
-  generatesUniqueRandomValues("randomOrThrow", gen => new GenOrThrow(gen).randomOrThrow())
-  throwsAnErrorWhenFiltered(
-    "randomOrThrow()",
-    implicit c => gen => new GenOrThrow(gen).randomOrThrow()
-  )
-
-  generatesUniqueRandomValues("tryGet.get", gen => new GenOrThrow(gen).tryGet.get)
-  throwsAnErrorWhenFiltered(
-    "tryGet.get",
-    _ => gen => new GenOrThrow(gen).tryGet.get,
-    minRetryLimit = 100
-  )
-
-  generatesTheSameValueWhenCalledTwice("tryGet (given the same Seed)", gen => new GenOrThrow(gen).tryGet(Seed(0)).get)
-
-  generatesUniqueRandomValues("sampleIterator.next()", gen => new GenOrThrow(gen).sampleIterator.next())
+  generatesUniqueRandomValues("sampleIterator.next()", _.sampleIterator.next())
   doesNotThrowAnErrorWhenFiltered(
     "sampleIterator.next()",
-    _ => gen => new GenOrThrow(gen).sampleIterator.next(),
+    _ => _.sampleIterator.next(),
     minRetryLimit = 100
   )
 
-  generatesUniqueRandomValues("toUnboundedIterator.next()", gen => new GenOrThrow(gen).toUnboundedIterator.next())
-  doesNotThrowAnErrorWhenFiltered(
-    "toUnboundedIterator.next()",
-    _ => gen => new GenOrThrow(gen).toUnboundedIterator.next(),
-    minRetryLimit = 100
-  )
-
-  generatesTheSameValueWhenCalledTwice("toIterator.next()", gen => new GenOrThrow(gen).toIterator.next())
-  generatesTheSameValueWhenCalledTwice("toIterator.take(3).toSeq", gen => new GenOrThrow(gen).toIterator.take(3).toSeq)
-  throwsAnErrorWhenFiltered(
-    "toIterator.next()",
-    _ => gen => new GenOrThrow(gen).toIterator.next(),
-    minRetryLimit = 100
-  )
-
-  generatesTheSameValueWhenCalledTwice("iterator.next()", gen => new GenOrThrow(gen).iterator.next())
-  generatesTheSameValueWhenCalledTwice("iterator.take(3).toSeq", gen => new GenOrThrow(gen).iterator.take(3).toSeq)
+  generatesTheSameValueWhenCalledTwice("iterator.next()", _.iterator.next())
+  generatesTheSameValueWhenCalledTwice("iterator.take(3).toSeq", _.iterator.take(3).toSeq)
   throwsAnErrorWhenFiltered(
     "iterator.next()",
-    implicit c => gen => new GenOrThrow(gen).iterator.next()
+    implicit c => _.iterator.next()
   )
-
 }

--- a/core/src/test/scala/org/scalacheck/ops/GenOrThrowSpec.scala
+++ b/core/src/test/scala/org/scalacheck/ops/GenOrThrowSpec.scala
@@ -5,6 +5,7 @@ import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
 import org.scalatest.freespec.AnyFreeSpec
 
+// TODO: Remove this after GenOrThrow is removed in the next major version
 class GenOrThrowSpec extends AnyFreeSpec
   with ScalaCheckImplicits {
 
@@ -46,7 +47,7 @@ class GenOrThrowSpec extends AnyFreeSpec
         count += 1
         count > retries + 1
       })
-      val ex = intercept[EmptyGenSampleException[UUID]] {
+      val ex = intercept[GenExceededRetryLimit] {
         methodCall(GenConfig.default.withRetries(retries))(gen)
       }
       assertResult(retries)(ex.attempts)
@@ -76,63 +77,63 @@ class GenOrThrowSpec extends AnyFreeSpec
     }
   }
 
-  generatesUniqueRandomValues("getOrThrow", _.getOrThrow)
+  generatesUniqueRandomValues("getOrThrow", gen => new GenOrThrow(gen).getOrThrow)
   throwsAnErrorWhenFiltered(
     "getOrThrow",
-    _ => _.getOrThrow,
+    _ => gen => new GenOrThrow(gen).getOrThrow,
     minRetryLimit = 100
   )
 
-  generatesTheSameValueWhenCalledTwice("getOrThrow (given the same Seed)", _.getOrThrow(Seed(0)))
+  generatesTheSameValueWhenCalledTwice("getOrThrow (given the same Seed)", gen => new GenOrThrow(gen).getOrThrow(Seed(0)))
 
-  generatesTheSameValueWhenCalledTwice("getOrThrowPure", _.getOrThrowPure)
+  generatesTheSameValueWhenCalledTwice("getOrThrowPure", gen => new GenOrThrow(gen).getOrThrowPure)
   throwsAnErrorWhenFiltered(
     "getOrThrowPure",
     implicit c => _.getOrThrowPure
   )
 
-  generatesUniqueRandomValues("randomOrThrow", _.randomOrThrow())
+  generatesUniqueRandomValues("randomOrThrow", gen => new GenOrThrow(gen).randomOrThrow())
   throwsAnErrorWhenFiltered(
     "randomOrThrow()",
-    implicit c => _.randomOrThrow()
+    implicit c => gen => new GenOrThrow(gen).randomOrThrow()
   )
 
-  generatesUniqueRandomValues("tryGet.get", _.tryGet.get)
+  generatesUniqueRandomValues("tryGet.get", gen => new GenOrThrow(gen).tryGet.get)
   throwsAnErrorWhenFiltered(
     "tryGet.get",
-    _ => _.tryGet.get,
+    _ => gen => new GenOrThrow(gen).tryGet.get,
     minRetryLimit = 100
   )
 
-  generatesTheSameValueWhenCalledTwice("tryGet (given the same Seed)", _.tryGet(Seed(0)).get)
+  generatesTheSameValueWhenCalledTwice("tryGet (given the same Seed)", gen => new GenOrThrow(gen).tryGet(Seed(0)).get)
 
-  generatesUniqueRandomValues("sampleIterator.next()", _.sampleIterator.next())
+  generatesUniqueRandomValues("sampleIterator.next()", gen => new GenOrThrow(gen).sampleIterator.next())
   doesNotThrowAnErrorWhenFiltered(
     "sampleIterator.next()",
-    _ => _.sampleIterator.next(),
+    _ => gen => new GenOrThrow(gen).sampleIterator.next(),
     minRetryLimit = 100
   )
 
-  generatesUniqueRandomValues("toUnboundedIterator.next()", _.toUnboundedIterator.next())
+  generatesUniqueRandomValues("toUnboundedIterator.next()", gen => new GenOrThrow(gen).toUnboundedIterator.next())
   doesNotThrowAnErrorWhenFiltered(
     "toUnboundedIterator.next()",
-    _ => _.toUnboundedIterator.next(),
+    _ => gen => new GenOrThrow(gen).toUnboundedIterator.next(),
     minRetryLimit = 100
   )
 
-  generatesTheSameValueWhenCalledTwice("toIterator.next()", _.toIterator.next())
-  generatesTheSameValueWhenCalledTwice("toIterator.take(3).toSeq", _.toIterator.take(3).toSeq)
+  generatesTheSameValueWhenCalledTwice("toIterator.next()", gen => new GenOrThrow(gen).toIterator.next())
+  generatesTheSameValueWhenCalledTwice("toIterator.take(3).toSeq", gen => new GenOrThrow(gen).toIterator.take(3).toSeq)
   throwsAnErrorWhenFiltered(
     "toIterator.next()",
-    _ => _.toIterator.next(),
+    _ => gen => new GenOrThrow(gen).toIterator.next(),
     minRetryLimit = 100
   )
 
-  generatesTheSameValueWhenCalledTwice("iterator.next()", _.iterator.next())
-  generatesTheSameValueWhenCalledTwice("iterator.take(3).toSeq", _.iterator.take(3).toSeq)
+  generatesTheSameValueWhenCalledTwice("iterator.next()", gen => new GenOrThrow(gen).iterator.next())
+  generatesTheSameValueWhenCalledTwice("iterator.take(3).toSeq", gen => new GenOrThrow(gen).iterator.take(3).toSeq)
   throwsAnErrorWhenFiltered(
     "iterator.next()",
-    implicit c => _.iterator.next()
+    implicit c => gen => new GenOrThrow(gen).iterator.next()
   )
 
 }

--- a/core/src/test/scala/org/scalacheck/ops/NewtypeExample.scala
+++ b/core/src/test/scala/org/scalacheck/ops/NewtypeExample.scala
@@ -1,0 +1,10 @@
+package org.scalacheck.ops
+
+import io.estatico.newtype.macros.{newsubtype, newtype}
+
+object NewtypeExample {
+  import scala.language.implicitConversions
+
+  @newtype class IdType(id: String)
+  @newsubtype class IdSubtype(id: String)
+}

--- a/core/src/test/scala/org/scalacheck/ops/NewtypeExample.scala
+++ b/core/src/test/scala/org/scalacheck/ops/NewtypeExample.scala
@@ -3,7 +3,7 @@ package org.scalacheck.ops
 import io.estatico.newtype.macros.{newsubtype, newtype}
 
 object NewtypeExample {
-  import scala.language.implicitConversions
+  import scala.language.{higherKinds, implicitConversions}
 
   @newtype class IdType(id: String)
   @newsubtype class IdSubtype(id: String)

--- a/core/src/test/scala/org/scalacheck/ops/NewtypeTypeNameSpec.scala
+++ b/core/src/test/scala/org/scalacheck/ops/NewtypeTypeNameSpec.scala
@@ -1,0 +1,18 @@
+package org.scalacheck.ops
+
+import org.scalatest.freespec.AnyFreeSpec
+
+class NewtypeTypeNameSpec extends AnyFreeSpec {
+
+  "Find a TypeName of a newtype" in {
+    assertResult("org.scalacheck.ops.NewtypeExample.IdType.Type") {
+      implicitly[TypeName[NewtypeExample.IdType]].typeName
+    }
+  }
+
+  "Find a TypeName of a newsubtype" in {
+    assertResult("org.scalacheck.ops.NewtypeExample.IdSubtype.Type") {
+      implicitly[TypeName[NewtypeExample.IdSubtype]].typeName
+    }
+  }
+}

--- a/core/src/test/scala/org/scalacheck/ops/time/TruncatedJavaTimeSpec.scala
+++ b/core/src/test/scala/org/scalacheck/ops/time/TruncatedJavaTimeSpec.scala
@@ -1,0 +1,50 @@
+package org.scalacheck.ops
+package time
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
+
+import java.time.{Instant, LocalDateTime}
+import java.time.temporal.{ChronoField, ChronoUnit}
+
+class TruncatedJavaTimeSpec extends AnyFreeSpec {
+
+  "Gen[Instant]" - {
+    val it = "Gen[Instant]"
+
+    s"$it.truncatedToMillis removes all nanoseconds and milliseconds" in {
+      forAll(Gen.javaInstant.beforeNow.truncatedToMillis) { instant: Instant =>
+        assertResult(0)(instant.getLong(ChronoField.NANO_OF_SECOND) % 1000)
+      }
+    }
+  }
+
+  "Gen[LocalDateTime]" - {
+    val it = "Gen[LocalDateTime]"
+
+    s"$it.truncatedToMillis removes all nanoseconds and milliseconds" in {
+      forAll(Gen.javaLocalDateTime.beforeNow.truncatedToMillis) { datetime: LocalDateTime =>
+        assertResult(0)(datetime.getLong(ChronoField.NANO_OF_SECOND) % 1000)
+      }
+    }
+
+    s"$it.truncatedTo(ChronoUnit.SECONDS) removes all milliseconds" in {
+      forAll(Gen.javaLocalDateTime.beforeNow.truncatedTo(ChronoUnit.SECONDS)) { datetime: LocalDateTime =>
+        assertResult(0)(datetime.getLong(ChronoField.MILLI_OF_SECOND))
+      }
+    }
+
+    s"$it.truncatedTo(ChronoUnit.MINUTES) removes all seconds" in {
+      forAll(Gen.javaLocalDateTime.beforeNow.truncatedTo(ChronoUnit.MINUTES)) { datetime: LocalDateTime =>
+        assertResult(0)(datetime.getLong(ChronoField.SECOND_OF_MINUTE))
+      }
+    }
+
+    s"$it.truncatedTo(ChronoUnit.HOURS) removes all seconds" in {
+      forAll(Gen.javaLocalDateTime.beforeNow.truncatedTo(ChronoUnit.HOURS)) { datetime: LocalDateTime =>
+        assertResult(0)(datetime.getLong(ChronoField.MINUTE_OF_HOUR))
+      }
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   final val Scala_2_11 = "2.11.12"
   final val Scala_2_12 = "2.12.12"
-  final val Scala_2_13 = "2.13.5"
+  final val Scala_2_13 = "2.13.6"
 
   final val ScalaCheck_1_12 = "1.12.6"
   final val ScalaCheck_1_13 = "1.13.5"
@@ -18,7 +18,7 @@ object Dependencies {
   // Once we no longer support ScalaCheck 1.13.x, we can upgrade to the latest version of
   // ScalaTest and always pull in the appropriate ScalaTestPlus artifact for ScalaCheck >= 1.14
   final private val ScalaTest_3_0 = "3.0.5"
-  final private val ScalaTest_3_2 = "3.2.7"
+  final private val ScalaTest_3_2 = "3.2.9"
 
   final private val ScalaTestPlusScalaCheckVersion = "3.2.2.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,9 +24,11 @@ object Dependencies {
 
   final private val IzumiReflectVersion = "1.1.2"
   final private val JodaTimeVersion = "2.10.10"
+  final private val NewtypeVersion = "0.4.4"
   final private val TaggingVersion = "2.3.0"
 
   val izumiReflect: ModuleID = "dev.zio" %% "izumi-reflect" % IzumiReflectVersion
+  val newtype: ModuleID = "io.estatico" %% "newtype" % NewtypeVersion
   val jodaTime: ModuleID = "joda-time" % "joda-time" % JodaTimeVersion
   val tagging: ModuleID = "com.softwaremill.common" %% "tagging" % TaggingVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,9 +22,11 @@ object Dependencies {
 
   final private val ScalaTestPlusScalaCheckVersion = "3.2.2.0"
 
+  final private val IzumiReflectVersion = "1.1.2"
   final private val JodaTimeVersion = "2.10.10"
   final private val TaggingVersion = "2.3.0"
 
+  val izumiReflect: ModuleID = "dev.zio" %% "izumi-reflect" % IzumiReflectVersion
   val jodaTime: ModuleID = "joda-time" % "joda-time" % JodaTimeVersion
   val tagging: ModuleID = "com.softwaremill.common" %% "tagging" % TaggingVersion
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.5.3


### PR DESCRIPTION
I ran into an issue where ScalaCheck needed a `ClassTag` of an id type which uses newtype and the compiler could not summon the implicit for it. These changes introduce a new set of extension methods that only require a `String` for the type name and can be provided explicitly or derived from a `TypeName[T]` which itself is derived implicitly from either a `ClassTag[T]` or a low priority implicit that use `izumi.reflect.Tag[T]` from https://github.com/zio/izumi-reflect (which is itself a more performant and type-safe replacement for Scala’s TypeTag to support Scala 3)

- Added implicit `TypeName` to support getting the type name (since `ClassTag` does not work for newtype).
- Added `GenFromConfig` extension methods to replace `GetOrThrow` extension methods
- Added `GenExceededRetryLimit` to replace `EmptyGenSampleException` (which requires a `ClassTag`)
- Deprecate `GetOrThrow` implicits, but keep it around for binary compatibility.
- Added unit tests for [newtype](https://github.com/estatico/scala-newtype).
- Bump version of sbt 1.5.3