### PR TITLE
Fix publishing of test dependencies in compile project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,8 +107,8 @@ def coreProject(srcPath: File, testPath: File, scalaCheckVersion: String): Proje
           )
         }
 
-      }.map(_ % Test)
-    }
+      }
+    }.map(_ % Test)
   )
 }
 


### PR DESCRIPTION
ScalaTest was being published as a compile scope dependency of the main project, rather than just a test scope dependency, as intended. This breaks certain sbt plugin validation checks at Rally.