### PR TITLE
Bugfix: Scoverage was always enabled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ def commonSettings(subProject: Option[String]): Seq[Setting[_]] = {
     Test / publishArtifact := false,
 
     // Disable coverage for Scala 2.11 -- sbt-scoverage no longer supports it
-    coverageEnabled := scalaBinaryVersion.value != "2.11"
+    coverageEnabled := (if (scalaBinaryVersion.value == "2.11") false else coverageEnabled.value)
   )
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   final val Scala_2_11 = "2.11.12"
   final val Scala_2_12 = "2.12.12"
   final val Scala_2_13 = "2.13.6"
-  final val Scala_3 = "3.1.0"
+  final val Scala_3 = "3.1.1"
 
   final private val ScalaTest_2_2 = "2.2.6"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0-M3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0-M4")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.0")


### PR DESCRIPTION
Found an issue with the way I was setting `coverageEnabled` - it was always enabled when not on Scala 2.11 (whoops). Fix it so it is now only enabled with `coverageOn` (for non-Scala 2.11) and disabled (on all versions) with `coverageOff`. 

Also bumped `sbt-coverage` plugin version and Scala 3 version.