### PR TITLE
Add OffsetDateTime Java Time Generators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies._
+import com.typesafe.tools.mima.core.{ProblemFilters, ReversedMissingMethodProblem}
 import sbt.Test
 
 // Aggregate root project settings only
@@ -51,6 +52,12 @@ def commonSettings(subProject: Option[String]): Seq[Setting[_]] = {
       else
         Set(organization.value %% artifact.value % mimaPreviousVersion.value)
     },
+
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "org.scalacheck.ops.time.ImplicitJavaTimeGenerators.arbOffsetDateTime"
+      )
+    ),
 
     scalacOptions ++= Seq(
       // "-Xfatal-warnings", // some methods in Scala 2.13 are deprecated, but I don't want to maintain to copies of source

--- a/core/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
+++ b/core/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
@@ -70,4 +70,12 @@ trait ImplicitJavaTimeGenerators {
       } yield ZonedDateTime.ofInstant(instant, zoneId)
     }
 
+  implicit lazy val arbOffsetDateTime: Arbitrary[OffsetDateTime] = {
+    Arbitrary {
+      for {
+        zoneId <- arbZoneId.arbitrary
+        instant <- arbInstant.arbitrary
+      } yield OffsetDateTime.ofInstant(instant, zoneId)
+    }
+  }
 }

--- a/core_1-12/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
+++ b/core_1-12/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
@@ -70,4 +70,13 @@ trait ImplicitJavaTimeGenerators {
       } yield ZonedDateTime.ofInstant(instant, zoneId)
     }
 
+  implicit lazy val arbOffsetDateTime: Arbitrary[OffsetDateTime] = {
+    Arbitrary {
+      for {
+        zoneId <- arbZoneId.arbitrary
+        instant <- arbInstant.arbitrary
+      } yield OffsetDateTime.ofInstant(instant, zoneId)
+    }
+  }
+
 }


### PR DESCRIPTION
Adds OffsetDateTime instances, its basically the exact same as the `Zoned` versions but uses `OffsetDateTime.ofInstant` instead