### PR TITLE
Improve syntax for generating collection types

### DIFF
--- a/core-1-13-test/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
+++ b/core-1-13-test/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
@@ -1,7 +1,6 @@
 package org.scalacheck.ops
 
 import org.scalacheck.Gen
-import org.scalacheck.rng.Seed
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks._
@@ -11,22 +10,6 @@ import scala.util.Try
 class GenOpsSpec extends FlatSpec {
 
   private def genDigits: Gen[Int] = Gen.choose(0, 100)
-
-  behavior.of("Gen.set")
-
-  it should "generate samples less than its sample size" in {
-    forAll(Gen.setOf(Gen.choose(0, 1))) { setOfDigits =>
-      assert(setOfDigits.size <= 2)
-    }
-  }
-
-  it should "generate the same samples when called twice with the same seed" in {
-    val gen = Gen.setOf(Gen.choose(0, 1))
-    val seed = Seed(1)
-    val a = gen.valueFor(seed)
-    val b = gen.valueFor(seed)
-    assert(a == b)
-  }
 
   behavior.of("Gen.collect")
 
@@ -57,6 +40,29 @@ class GenOpsSpec extends FlatSpec {
     }
   }
 
+  behavior.of("Gen.of[Stream]")
+
+  it should "generate samples less than the default size" in {
+    forAll(Gen.of[Stream](Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= Gen.Parameters.default.size)
+    }
+  }
+
+  it should "be able to generate a certain size" in {
+    val n = 10
+    forAll(Gen.of[Stream](n, genDigits)) { digits =>
+      assertResult(n)(digits.size)
+    }
+  }
+
+  behavior.of("Gen.set")
+
+  it should "generate samples less than its sample size" in {
+    forAll(Gen.setOf(Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= 2)
+    }
+  }
+
   behavior.of("Gen.setOfN")
 
   it should "be able to generate a certain size" in {
@@ -66,14 +72,24 @@ class GenOpsSpec extends FlatSpec {
     }
   }
 
-  it should "generate the same samples when called twice with the same seed" in {
-    val n = 10
-    val gen = Gen.setOfN(n, genDigits)
-    val seed = Seed(n)
-    val a = gen.valueFor(seed)
-    val b = gen.valueFor(seed)
-    assert(a == b)
+  behavior.of("Gen.vectorOf")
+
+  it should "generate samples less than the default size" in {
+    forAll(Gen.vectorOf(Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= Gen.Parameters.default.size)
+    }
   }
+
+  behavior.of("Gen.vectorOfN")
+
+  it should "be able to generate a certain size" in {
+    val n = 10
+    forAll(Gen.vectorOfN(n, genDigits)) { digits =>
+      assertResult(n)(digits.size)
+    }
+  }
+
+  behavior.of("Gen[Iterator]")
 
   private val genOnesIter: Gen[Iterator[Int]] =
     Gen.const(Gen.oneOf(0, 1)).flatMap(_.filter(Set(1)).toUnboundedIterator)

--- a/core/src/main/scala/org/scalacheck/ops/GenOps.scala
+++ b/core/src/main/scala/org/scalacheck/ops/GenOps.scala
@@ -1,5 +1,6 @@
 package org.scalacheck.ops
 
+import org.scalacheck.util.Buildable
 import org.scalacheck.{Arbitrary, Gen}
 
 import scala.collection.{mutable, BitSet}
@@ -77,6 +78,15 @@ object GenOps {
   ): Gen[Set[T]] = setOfN(size, 50, tGen)
 
   def setOf[T](implicit arbT: Arbitrary[T]): Gen[Set[T]] = Gen.listOf(arbT.arbitrary).map(_.toSet[T])
+
+  def vectorOf[T](tGen: Gen[T]): Gen[Vector[T]] = Gen.containerOf[Vector, T](tGen)
+
+  def vectorOfN[T](
+    size: Int,
+    tGen: Gen[T]
+  ): Gen[Vector[T]] = Gen.containerOfN[Vector, T](size, tGen)
+
+  def of[C[_]]: GenOfPartiallyApplied[C] = new GenOfPartiallyApplied[C]
 }
 
 /** Mixin for some helpful implicits when dealing with ScalaCheck generator monads.
@@ -89,4 +99,23 @@ class GenOps[T](val gen: Gen[T]) extends AnyVal {
   /** Flattens a generator of generators into a single generator.
     */
   def flatten[U](implicit ev: T <:< Gen[U]): Gen[U] = gen.flatMap(ev)
+}
+
+class GenOfPartiallyApplied[C[_]](private val dummy: Boolean = true) extends AnyVal {
+
+  def apply[T](
+    tGen: Gen[T]
+  )(implicit
+    buildable: Buildable[T, C[T]],
+    iterable: C[T] => Iterable[T]
+  ): Gen[C[T]] = Gen.containerOf[C, T](tGen)
+
+  def apply[T](
+    size: Int,
+    tGen: Gen[T]
+  )(implicit
+    buildable: Buildable[T, C[T]],
+    iterable: C[T] => Iterable[T]
+  ): Gen[C[T]] = Gen.containerOfN[C, T](size, tGen)
+
 }

--- a/core/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
+++ b/core/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
@@ -12,23 +12,6 @@ class GenOpsSpec extends AnyFlatSpec {
 
   private def genDigits: Gen[Int] = Gen.choose(0, 100)
 
-  behavior.of("Gen.set")
-
-  it should "generate samples less than its sample size" in {
-    forAll(Gen.setOf(Gen.choose(0, 1))) { setOfDigits =>
-      assert(setOfDigits.size <= 2)
-    }
-  }
-
-  it should "generate the same samples when called twice with the same seed" in {
-    val gen = Gen.setOf(Gen.choose(0, 1))
-    val seed = Seed(1)
-    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
-    val a = gen.head
-    val b = gen.head
-    assert(a == b)
-  }
-
   behavior.of("Gen.collect")
 
   it should "use suchThat when retryUntilMatch is false" in {
@@ -58,6 +41,84 @@ class GenOpsSpec extends AnyFlatSpec {
     }
   }
 
+  behavior.of("Gen.of[Stream]")
+
+  it should "generate samples less than the default size" in {
+    forAll(Gen.of[Stream](Gen.choose(0, 1))) { setOfDigits =>
+      assert(setOfDigits.size <= Gen.Parameters.default.size)
+    }
+  }
+
+  it should "generate the same samples when called twice with the same seed" in {
+    val gen = Gen.of[Stream](Gen.choose(0, 1))
+    val seed = Seed(1)
+    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
+    val a = gen.head
+    val b = gen.head
+    assert(a == b)
+  }
+
+  it should "be able to generate a certain size" in {
+    val n = 10
+    forAll(Gen.of[Stream](n, genDigits)) { digits =>
+      assertResult(n)(digits.size)
+    }
+  }
+
+  it should "generate the same samples when called twice with the same size and seed" in {
+    val n = 10
+    val gen = Gen.of[Stream](n, genDigits)
+    val seed = Seed(n)
+    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
+    val a = gen.head
+    val b = gen.head
+    assert(a == b)
+  }
+
+  behavior.of("Gen.of[Set]")
+
+  it should "generate samples less than its sample size" in {
+    forAll(Gen.of[Set](Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= 2)
+    }
+  }
+
+  it should "generate the same samples when called twice with the same seed" in {
+    val gen = Gen.of[Set](Gen.choose(0, 1))
+    val seed = Seed(1)
+    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
+    val a = gen.head
+    val b = gen.head
+    assert(a == b)
+  }
+
+  it should "generate the same samples when called twice with the same size and seed" in {
+    val n = 10
+    val gen = Gen.of[Set](n, genDigits)
+    val seed = Seed(n)
+    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
+    val a = gen.head
+    val b = gen.head
+    assert(a == b)
+  }
+
+  behavior.of("Gen.set")
+
+  it should "generate samples less than its sample size" in {
+    forAll(Gen.setOf(Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= 2)
+    }
+  }
+
+  it should "generate the same samples when called twice with the same seed" in {
+    val gen = Gen.setOf(Gen.choose(0, 1))
+    val seed = Seed(1)
+    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
+    val a = gen.head
+    val b = gen.head
+    assert(a == b)
+  }
+
   behavior.of("Gen.setOfN")
 
   it should "be able to generate a certain size" in {
@@ -67,7 +128,7 @@ class GenOpsSpec extends AnyFlatSpec {
     }
   }
 
-  it should "generate the same samples when called twice with the same seed" in {
+  it should "generate the same samples when called twice with the same size and seed" in {
     val n = 10
     val gen = Gen.setOfN(n, genDigits)
     val seed = Seed(n)
@@ -76,6 +137,44 @@ class GenOpsSpec extends AnyFlatSpec {
     val b = gen.head
     assert(a == b)
   }
+
+  behavior.of("Gen.vectorOf")
+
+  it should "generate samples less than the default size" in {
+    forAll(Gen.vectorOf(Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= Gen.Parameters.default.size)
+    }
+  }
+
+  it should "generate the same samples when called twice with the same seed" in {
+    val gen = Gen.vectorOf(Gen.choose(0, 1))
+    val seed = Seed(1)
+    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
+    val a = gen.head
+    val b = gen.head
+    assert(a == b)
+  }
+
+  behavior.of("Gen.vectorOfN")
+
+  it should "be able to generate a certain size" in {
+    val n = 10
+    forAll(Gen.vectorOfN(n, genDigits)) { digits =>
+      assertResult(n)(digits.size)
+    }
+  }
+
+  it should "generate the same samples when called twice with the same size and seed" in {
+    val n = 10
+    val gen = Gen.vectorOfN(n, genDigits)
+    val seed = Seed(n)
+    implicit val gc: GenConfig = GenConfig.default.withSeed(seed)
+    val a = gen.head
+    val b = gen.head
+    assert(a == b)
+  }
+
+  behavior.of("Gen[Iterator]")
 
   private val genOnesIter: Gen[Iterator[Int]] =
     Gen.const(Gen.oneOf(0, 1)).flatMap(_.filter(Set(1)).iterator)

--- a/core_1-12/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
+++ b/core_1-12/src/test/scala/org/scalacheck/ops/GenOpsSpec.scala
@@ -10,14 +10,6 @@ class GenOpsSpec extends FlatSpec with Matchers with ScalaCheckImplicits {
 
   private def genDigits: Gen[Int] = Gen.choose(0, 100)
 
-  behavior.of("Gen.set")
-
-  it should "generate samples less than its sample size" in {
-    forAll(Gen.setOf(Gen.choose(0, 1))) { setOfDigits =>
-      assert(setOfDigits.size <= 2)
-    }
-  }
-
   behavior.of("Gen.collect")
 
   it should "use suchThat when retryUntilMatch is false" in {
@@ -47,6 +39,29 @@ class GenOpsSpec extends FlatSpec with Matchers with ScalaCheckImplicits {
     }
   }
 
+  behavior.of("Gen.of[Stream]")
+
+  it should "generate samples less than the default size" in {
+    forAll(Gen.of[Stream](Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= Gen.Parameters.default.size)
+    }
+  }
+
+  it should "be able to generate a certain size" in {
+    val n = 10
+    forAll(Gen.of[Stream](n, genDigits)) { digits =>
+      assertResult(n)(digits.size)
+    }
+  }
+
+  behavior.of("Gen.set")
+
+  it should "generate samples less than its sample size" in {
+    forAll(Gen.setOf(Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= 2)
+    }
+  }
+
   behavior.of("Gen.setOfN")
 
   it should "be able to generate a certain size" in {
@@ -55,6 +70,25 @@ class GenOpsSpec extends FlatSpec with Matchers with ScalaCheckImplicits {
       assertResult(n)(digits.size)
     }
   }
+
+  behavior.of("Gen.vectorOf")
+
+  it should "generate samples less than the default size" in {
+    forAll(Gen.vectorOf(Gen.choose(0, 1))) { digits =>
+      assert(digits.size <= Gen.Parameters.default.size)
+    }
+  }
+
+  behavior.of("Gen.vectorOfN")
+
+  it should "be able to generate a certain size" in {
+    val n = 10
+    forAll(Gen.vectorOfN(n, genDigits)) { digits =>
+      assertResult(n)(digits.size)
+    }
+  }
+
+  behavior.of("Gen[Iterator]")
 
   private val genOnesIter: Gen[Iterator[Int]] =
     Gen.const(Gen.oneOf(0, 1)).flatMap(_.filter(Set(1)).toUnboundedIterator)


### PR DESCRIPTION
- Add Gen.of[C] for easier syntax with collections
- Add Gen.vectorOf and Gen.vectorOfN for common collection type