### PR TITLE
Add support for Scalacheck 1.16.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,12 @@ def commonSettings(subProject: Option[String]): Seq[Setting[_]] = {
   Seq(
     name := artifact.value,
 
-    mimaPreviousArtifacts := Set(organization.value %% artifact.value % mimaPreviousVersion.value),
+    mimaPreviousArtifacts := {
+      if (ScalaCheckAxis.current.value.scalaCheckVersion == ScalaCheckAxis.v1_16.scalaCheckVersion)
+        Set.empty
+      else
+        Set(organization.value %% artifact.value % mimaPreviousVersion.value)
+    },
 
     scalacOptions ++= Seq(
       // "-Xfatal-warnings", // some methods in Scala 2.13 are deprecated, but I don't want to maintain to copies of source
@@ -110,6 +115,14 @@ lazy val `core` = projectMatrix
         ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
     )
   )
+  .customRow(
+    scalaVersions = ScalaCheckAxis.v1_16.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1_16, VirtualAxis.jvm),
+    settings = Seq(
+      libraryDependencies +=
+        ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
+    )
+  )
 
 lazy val `joda` = projectMatrix
   .settings(commonSettings(subProject = Some("joda")))
@@ -139,5 +152,10 @@ lazy val `joda` = projectMatrix
   .customRow(
     scalaVersions = ScalaCheckAxis.v1_15.scalaVersions,
     axisValues = Seq(ScalaCheckAxis.v1_15, VirtualAxis.jvm),
+    settings = Nil
+  )
+  .customRow(
+    scalaVersions = ScalaCheckAxis.v1_16.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1_16, VirtualAxis.jvm),
     settings = Nil
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,10 +18,13 @@ object Dependencies {
   // ScalaTest and always pull in the appropriate ScalaTestPlus artifact for ScalaCheck >= 1.14
   final private val ScalaTest_3_0 = "3.0.5"
   final private val ScalaTest_3_2 = "3.2.9"
+  final private val scalaTest_3_2_14 = "3.2.14"
 
-  private def scalaTestPlusScalaCheckVersion(scalaVer: String) = CrossVersion.partialVersion(scalaVer) match {
-    case Some((3, _)) => "3.2.10.0"
-    case _ => "3.2.2.0"
+  private def scalaTestPlusScalaCheckVersion(scalaVer: String, scalaCheckVersion: String) =
+    (CrossVersion.partialVersion(scalaVer), scalaCheckVersion) match {
+      case (_, ScalaCheckAxis.v1_16.scalaCheckVersion) => "3.2.14.0"
+      case (Some((3, _)),_) => "3.2.10.0"
+      case _ => "3.2.2.0"
   }
 
   final private val IzumiReflectVersion = "1.1.2"
@@ -57,7 +60,7 @@ object Dependencies {
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test
 
     def scalaTestPlusScalaCheck(scalaVer: String): ModuleID =
-      "org.scalatestplus" %% s"scalacheck-$id" % scalaTestPlusScalaCheckVersion(scalaVer) % Test
+      "org.scalatestplus" %% s"scalacheck-$id" % scalaTestPlusScalaCheckVersion(scalaVer, scalaCheckVersion) % Test
   }
 
   object ScalaCheckAxis extends CurrentAxis[ScalaCheckAxis] {
@@ -65,6 +68,7 @@ object Dependencies {
     val v1_13 = ScalaCheckAxis("1-13", "1.13.5", ScalaTest_3_0, Seq(Scala_2_11, Scala_2_12))
     val v1_14 = ScalaCheckAxis("1-14", "1.14.3", ScalaTest_3_2, Seq(Scala_2_11, Scala_2_12, Scala_2_13))
     val v1_15 = ScalaCheckAxis("1-15", "1.15.4", ScalaTest_3_2, Seq(Scala_2_12, Scala_2_13, Scala_3))
+    val v1_16 = ScalaCheckAxis("1-16", "1.16.0", scalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
   }
 
   abstract class CurrentAxis[T: ClassTag] {


### PR DESCRIPTION
This PR adds support for Scalacheck `1.16.0` (see https://github.com/rallyhealth/scalacheck-ops/issues/52). Note that `1.17.0` is not possible yet due to scalatest not making a release for it yet.

One thing to note is that for `org.scalatestplus` there are multiple versions (see https://repo1.maven.org/maven2/org/scalatestplus/scalacheck-1-16_2.13/) so I picked the latest which is `3.2.14.0`. Also for the same reason the logic of `scalaTestPlusScalaCheckVersion` had to be updated so that it can handle the new `3.2.14.0`.

If https://github.com/rallyhealth/scalacheck-ops/pull/54 is merged before this PR its also trivial to rebase this PR to add Scala.js/native support.