### PR TITLE
Update and apply scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v1
+        with:
+          version: '3.5.9'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,26 +1,16 @@
-name: Scalafmt
-
-permissions: read-all
-
+name: Format
 on:
   pull_request:
     branches: ['**']
 
 jobs:
   build:
-    name: Code is formatted
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    name: pre-commit
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: coursier/setup-action@v1
+      - uses: pre-commit/action@v3.0.0
         with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v1
-        with:
-          version: '3.5.9'
+          extra_args: --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,10 @@
 repos:
-- repo: https://github.com/softwaremill/scala-pre-commit-hooks
-  rev: v0.3.0
-  hooks:
-  - id: sbt-scalafmt
-    stages: [commit]
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
-  hooks:
-  - id: end-of-file-fixer
-  - id: trailing-whitespace
+  - repo: https://github.com/jeffmay/pre-commit-hooks-scala
+    rev: v0.0.1
+    hooks:
+      - id: scalafmt
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -42,7 +42,7 @@ newlines {
   # This looks kinda gross with the rest of the format. We take strides to ensure that we chop down long parameter lists.
   sometimesBeforeColonInMethodReturnType = false
 
-  implicitParamListModifierForce=[after]
+  implicitParamListModifierForce = [after]
 }
 
 # Prevent wrapping of docstrings so that they appear on a single line

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,16 +4,15 @@
 # - verticalMultiline.arityThreshold = 2
 # - rewrite.redundantBraces.methodBodies = false
 #
-# TODO: Use 3.x
-version = "2.7.5"
-
+version = "3.5.9"
+runner.dialect = scala213
 # Only format files tracked by git (we don't care what crazy you make that you don't commit ;)
 project.git = true
 
 # The Scala style guide is not explicit about alignment but does have multiple examples that show you should NOT align:
 # https://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
 # https://docs.scala-lang.org/style/control-structures.html#curly-braces
-align = none
+align.preset = none
 
 # Bumped from the default of 80 because we live in the age of wide-screen laptops and 4K monitors not punch cards with
 # 80 characters
@@ -38,11 +37,16 @@ newlines {
   # The Scala style guide is not explicit about blank lines but does have multiple examples of using them:
   # https://docs.scala-lang.org/style/files.html
   # https://docs.scala-lang.org/style/scaladoc.html#packages
-  alwaysBeforeTopLevelStatements = true
+  topLevelStatements = [before]
 
   # This looks kinda gross with the rest of the format. We take strides to ensure that we chop down long parameter lists.
   sometimesBeforeColonInMethodReturnType = false
+
+  implicitParamListModifierForce=[after]
 }
+
+# Prevent wrapping of docstrings so that they appear on a single line
+docstrings.wrap = false
 
 # Chops down ALL method signatures with more than one argument.
 # https://scalameta.org/scalafmt/docs/configuration.html#forcing-config-style
@@ -56,10 +60,11 @@ verticalMultiline {
   # https://scalameta.org/scalafmt/docs/configuration.html#vertical-multiline
   arityThreshold = 2
   atDefnSite = true
-  excludeDanglingParens = []
   newlineAfterOpenParen = true
-  newlineBeforeImplicitKW = false
-  newlineAfterImplicitKW = true
+}
+
+danglingParentheses {
+  exclude = []
 }
 
 rewrite {

--- a/build.sbt
+++ b/build.sbt
@@ -30,29 +30,31 @@ def commonSettings(subProject: Option[String]): Seq[Setting[_]] = {
   val mimaPreviousVersion = scalaBinaryVersion(v => if (v == "3") "2.8.0" else "2.6.0")
   Seq(
     name := artifact.value,
-
     mimaPreviousArtifacts := {
       if (ScalaCheckAxis.current.value.scalaCheckVersion == ScalaCheckAxis.v1_16.scalaCheckVersion)
         Set.empty
       else
         Set(organization.value %% artifact.value % mimaPreviousVersion.value)
     },
-
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "org.scalacheck.ops.time.ImplicitJavaTimeGenerators.arbOffsetDateTime"
       )
     ),
-
     scalacOptions ++= Seq(
       // "-Xfatal-warnings", // some methods in Scala 2.13 are deprecated, but I don't want to maintain to copies of source
       "-deprecation:false",
       "-feature",
-      "-encoding", "UTF-8"
-    ) ++ (if (scalaBinaryVersion.value == "3") Nil else Seq(
-      "-Xlint",
-      "-Ywarn-dead-code"
-    )),
+      "-encoding",
+      "UTF-8"
+    ) ++ {
+      if (scalaBinaryVersion.value == "3") Nil
+      else
+        Seq(
+          "-Xlint",
+          "-Ywarn-dead-code"
+        )
+    },
 
     // Allow publishing ScalaDoc by disabling link warnings
     Compile / doc / scalacOptions += "--no-link-warnings",
@@ -69,12 +71,10 @@ lazy val core = projectMatrix
     // default locations, overridden in custom rows where needed
     Compile / sourceDirectory := (file("core") / "src" / "main").getAbsoluteFile,
     Test / sourceDirectory := (file("core") / "src" / "test").getAbsoluteFile,
-
     scalacOptions ++= (scalaVersion.value match {
       case Scala_2_13 => Seq("-Ymacro-annotations")
       case _ => Nil
     }),
-
     libraryDependencies ++= Seq(
       izumiReflect,
       tagging,
@@ -82,9 +82,10 @@ lazy val core = projectMatrix
       newtype, // Test-only
       ScalaCheckAxis.current.value.scalaTest // Test-only
     ) ++ (scalaVersion.value match {
-      case CrossVersion.PartialVersion("2", "12", _*) => Seq(
-        compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
-      )
+      case CrossVersion.PartialVersion("2", "12", _*) =>
+        Seq(
+          compilerPlugin(("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full))
+        )
       case _ => Nil
     })
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,27 +9,30 @@ object Dependencies {
   final val Scala_2_13 = "2.13.6"
   final val Scala_3 = "3.1.1"
 
-  final private val ScalaTest_2_2 = "2.2.6"
+  private final val ScalaTest_2_2 = "2.2.6"
 
   // Newer versions of ScalaTest separate the scalatestplus %% scalacheck-1-X dependencies,
   // but do not support ScalaCheck 1.13.x
   // Once we no longer support ScalaCheck 1.13.x, we can upgrade to the latest version of
   // ScalaTest and always pull in the appropriate ScalaTestPlus artifact for ScalaCheck >= 1.14
-  final private val ScalaTest_3_0 = "3.0.5"
-  final private val ScalaTest_3_2 = "3.2.9"
-  final private val scalaTest_3_2_14 = "3.2.14"
+  private final val ScalaTest_3_0 = "3.0.5"
+  private final val ScalaTest_3_2 = "3.2.9"
+  private final val scalaTest_3_2_14 = "3.2.14"
 
-  private def scalaTestPlusScalaCheckVersion(scalaVer: String, scalaCheckVersion: String) =
+  private def scalaTestPlusScalaCheckVersion(
+    scalaVer: String,
+    scalaCheckVersion: String
+  ) =
     (CrossVersion.partialVersion(scalaVer), scalaCheckVersion) match {
       case (_, ScalaCheckAxis.v1_16.scalaCheckVersion) => "3.2.14.0"
-      case (Some((3, _)),_) => "3.2.10.0"
+      case (Some((3, _)), _) => "3.2.10.0"
       case _ => "3.2.2.0"
-  }
+    }
 
-  final private val IzumiReflectVersion = "1.1.2"
-  final private val JodaTimeVersion = "2.10.10"
-  final private val NewtypeVersion = "0.4.4"
-  final private val TaggingVersion = "2.3.2"
+  private final val IzumiReflectVersion = "1.1.2"
+  private final val JodaTimeVersion = "2.10.10"
+  private final val NewtypeVersion = "0.4.4"
+  private final val TaggingVersion = "2.3.2"
 
   val izumiReflect: ModuleID = "dev.zio" %% "izumi-reflect" % IzumiReflectVersion
   val newtype: ModuleID = for3Use2("io.estatico" %% "newtype" % NewtypeVersion) % Test
@@ -69,7 +72,7 @@ object Dependencies {
     val v1_16 = ScalaCheckAxis("1-16", "1.16.0", scalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
   }
 
-  abstract class CurrentAxis[T: ClassTag] {
+  abstract class CurrentAxis[T : ClassTag] {
 
     def current: Def.Initialize[T] = Def.setting {
       virtualAxes.value.collectFirst { case a: T => a }.get


### PR DESCRIPTION
## Description

This PR updates the scalafmt config to the newest version as well as replacing a pre commit git hook with a github workflow action. This may be subjective but I have a personal hate with putting formatters within githooks because it really messes with IDE's especially in large codebases. Instead the github workflow action

* Runs concurrently to the main build and uses the scala-native version of  scalafmt. This means its ultra fast, taking only around 2-3 seconds on small projects
* You can add the check to the list of branch checks that must pass before merging a PR to enforce not being able to merge unformatted code, i.e.
<img width="754" alt="image" src="https://user-images.githubusercontent.com/2337269/194536755-b198e2cc-a2a8-4e4f-a146-da95c024bfa9.png">


## Type of change

Updating of scalafmt

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
