### PR TITLE
Remove redundant checking for code style in checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,6 @@ Fixes # (issue)
 
 ## Checklist:
 
-- [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation


### PR DESCRIPTION
## Description

This checklist entry is redundant since we use scalafmt which actually enforces that code must be formatted even for it to pass the CI (especially after https://github.com/rallyhealth/scalacheck-ops/pull/57 is merged)

## Checklist:

- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
