### PR TITLE
✨ Add support for scalacheck 1.17 using a shared 1.x artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,23 +52,23 @@ jobs:
           core/target/1-15-jvm-3 \
           core/target/1-15-native-2.13 \
           core/target/1-15-native-3 \
-          core/target/1-16-js-2.12 \
-          core/target/1-16-js-2.13 \
-          core/target/1-16-js-3 \
-          core/target/1-16-jvm-2.12 \
-          core/target/1-16-jvm-2.13 \
-          core/target/1-16-jvm-3 \
-          core/target/1-16-native-2.13 \
-          core/target/1-16-native-3 \
+          core/target/1-js-2.12 \
+          core/target/1-js-2.13 \
+          core/target/1-js-3 \
+          core/target/1-jvm-2.12 \
+          core/target/1-jvm-2.13 \
+          core/target/1-jvm-3 \
+          core/target/1-native-2.13 \
+          core/target/1-native-3 \
           joda/target/1-13-jvm-2.12 \
           joda/target/1-14-jvm-2.12 \
           joda/target/1-14-jvm-2.13 \
           joda/target/1-15-jvm-2.12 \
           joda/target/1-15-jvm-2.13 \
           joda/target/1-15-jvm-3 \
-          joda/target/1-16-jvm-2.12 \
-          joda/target/1-16-jvm-2.13 \
-          joda/target/1-16-jvm-3 \
+          joda/target/1-jvm-2.12 \
+          joda/target/1-jvm-2.13 \
+          joda/target/1-jvm-3 \
           project/target \
           target
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,10 +31,12 @@ def commonSettings(subProject: Option[String]): Seq[Setting[_]] = {
   Seq(
     name := artifact.value,
     mimaPreviousArtifacts := {
-      if (ScalaCheckAxis.current.value.scalaCheckVersion == ScalaCheckAxis.v1_16.scalaCheckVersion)
-        Set.empty
-      else
-        Set(organization.value %% artifact.value % mimaPreviousVersion.value)
+      val scVersion = ScalaCheckAxis.current.value.scalaCheckVersion
+      CrossVersion.partialVersion(scVersion) match {
+        case Some((1, x)) if x > 15 => Set.empty
+        case _ =>
+          Set(organization.value %% artifact.value % mimaPreviousVersion.value)
+      }
     },
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem](
@@ -113,8 +115,8 @@ lazy val core = projectMatrix
     )
   )
   .customRow(
-    scalaVersions = ScalaCheckAxis.v1_16.scalaVersions,
-    axisValues = Seq(ScalaCheckAxis.v1_16, VirtualAxis.jvm),
+    scalaVersions = ScalaCheckAxis.v1.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1, VirtualAxis.jvm),
     settings = Seq(
       libraryDependencies +=
         ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
@@ -129,8 +131,8 @@ lazy val core = projectMatrix
     )
   )
   .jsPlatform(
-    scalaVersions = ScalaCheckAxis.v1_16.scalaVersions,
-    axisValues = Seq(ScalaCheckAxis.v1_16),
+    scalaVersions = ScalaCheckAxis.v1.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1),
     settings = Seq(
       libraryDependencies +=
         ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
@@ -145,8 +147,8 @@ lazy val core = projectMatrix
     )
   )
   .nativePlatform(
-    scalaVersions = ScalaCheckAxis.v1_16.scalaVersions.filterNot(_ == Scala_2_12),
-    axisValues = Seq(ScalaCheckAxis.v1_16),
+    scalaVersions = ScalaCheckAxis.v1.scalaVersions.filterNot(_ == Scala_2_12),
+    axisValues = Seq(ScalaCheckAxis.v1),
     settings = Seq(
       libraryDependencies +=
         ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
@@ -179,7 +181,7 @@ lazy val joda = projectMatrix
     settings = Nil
   )
   .customRow(
-    scalaVersions = ScalaCheckAxis.v1_16.scalaVersions,
-    axisValues = Seq(ScalaCheckAxis.v1_16, VirtualAxis.jvm),
+    scalaVersions = ScalaCheckAxis.v1.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1, VirtualAxis.jvm),
     settings = Nil
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,25 +9,13 @@ object Dependencies {
   final val Scala_2_13 = "2.13.6"
   final val Scala_3 = "3.1.1"
 
-  private final val ScalaTest_2_2 = "2.2.6"
-
   // Newer versions of ScalaTest separate the scalatestplus %% scalacheck-1-X dependencies,
   // but do not support ScalaCheck 1.13.x
   // Once we no longer support ScalaCheck 1.13.x, we can upgrade to the latest version of
   // ScalaTest and always pull in the appropriate ScalaTestPlus artifact for ScalaCheck >= 1.14
   private final val ScalaTest_3_0 = "3.0.5"
-  private final val ScalaTest_3_2 = "3.2.9"
-  private final val scalaTest_3_2_14 = "3.2.14"
-
-  private def scalaTestPlusScalaCheckVersion(
-    scalaVer: String,
-    scalaCheckVersion: String
-  ) =
-    (CrossVersion.partialVersion(scalaVer), scalaCheckVersion) match {
-      case (_, ScalaCheckAxis.v1_16.scalaCheckVersion) => "3.2.14.0"
-      case (Some((3, _)), _) => "3.2.10.0"
-      case _ => "3.2.2.0"
-    }
+  private final val ScalaTest_3_2_9 = "3.2.9"
+  private final val ScalaTest_3_2_14 = "3.2.14"
 
   private final val IzumiReflectVersion = "1.1.2"
   private final val JodaTimeVersion = "2.10.10"
@@ -46,6 +34,10 @@ object Dependencies {
     scalaVersions: Seq[String]
   ) extends VirtualAxis.WeakAxis {
 
+    private val scPartialVersion = CrossVersion.partialVersion(scalaCheckVersion).getOrElse {
+      throw new IllegalArgumentException(s"scalaCheckVersion '$scalaCheckVersion' is not a valid semantic version.")
+    }
+
     override def idSuffix: String = s"_$id"
 
     override def directorySuffix: String = s"-$id"
@@ -61,15 +53,26 @@ object Dependencies {
     def scalaTest: ModuleID =
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test
 
-    def scalaTestPlusScalaCheck(scalaVer: String): ModuleID =
-      "org.scalatestplus" %% s"scalacheck-$id" % scalaTestPlusScalaCheckVersion(scalaVer, scalaCheckVersion) % Test
+    def scalaTestPlusScalaCheck(scalaVer: String): ModuleID = {
+      val version = (CrossVersion.partialVersion(scalaVer), scPartialVersion) match {
+        case (_, (1, x)) if x > 15 => "3.2.14.0"
+        case (Some((3, _)), _) => "3.2.10.0"
+        case _ => "3.2.2.0"
+      }
+      val suffix = scPartialVersion.productIterator.mkString("-")
+      "org.scalatestplus" %% s"scalacheck-$suffix" % version % Test
+    }
   }
 
   object ScalaCheckAxis extends CurrentAxis[ScalaCheckAxis] {
-    val v1_13 = ScalaCheckAxis("1-13", "1.13.5", ScalaTest_3_0, Seq(Scala_2_12))
-    val v1_14 = ScalaCheckAxis("1-14", "1.14.3", ScalaTest_3_2, Seq(Scala_2_12, Scala_2_13))
-    val v1_15 = ScalaCheckAxis("1-15", "1.15.4", ScalaTest_3_2, Seq(Scala_2_12, Scala_2_13, Scala_3))
-    val v1_16 = ScalaCheckAxis("1-16", "1.16.0", scalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
+    final val v1_13 = ScalaCheckAxis("1-13", "1.13.5", ScalaTest_3_0, Seq(Scala_2_12))
+    final val v1_14 = ScalaCheckAxis("1-14", "1.14.3", ScalaTest_3_2_9, Seq(Scala_2_12, Scala_2_13))
+    final val v1_15 = ScalaCheckAxis("1-15", "1.15.4", ScalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
+
+    // All scalacheck releases after 1.14 use semantic versioning, so it should be safe to pin to the latest
+    // version of scalacheck v1.x at this point. If this changes, we can continue to add version specific aliases
+    // as well.
+    final val v1 = ScalaCheckAxis("1", "1.17.0", ScalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
   }
 
   abstract class CurrentAxis[T : ClassTag] {
@@ -79,6 +82,6 @@ object Dependencies {
     }
   }
 
-  def for3Use2(m: ModuleID) = m.cross(CrossVersion.for3Use2_13)
+  def for3Use2(m: ModuleID): ModuleID = m.cross(CrossVersion.for3Use2_13)
 
 }


### PR DESCRIPTION
## Description

An alternative implementation to support ScalaCheck 1.17.0 to https://github.com/rallyhealth/scalacheck-ops/pull/65

Upgrades to scalacheck 1.17 by using a shared v1.x axis and removes the 1-16 artifact.

## Type of change

- [x] Breaking change (not really -- if you skip the already broken release of [scalacheck-ops v2.10.0](https://github.com/rallyhealth/scalacheck-ops/releases/tag/v2.10.0), there is no breaking change -- otherwise, the only "breaking" change is that `scalacheck-ops_1-17` will no longer be published)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
  I will update the README once the Scala.js and Scala native artifacts are published
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
