### PR TITLE
✨ Add support for scalacheck 1.17 using a new 1-17 artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
           core/target/1-16-jvm-3 \
           core/target/1-16-native-2.13 \
           core/target/1-16-native-3 \
+          core/target/1-17-js-2.12 \
+          core/target/1-17-js-2.13 \
+          core/target/1-17-js-3 \
+          core/target/1-17-jvm-2.12 \
+          core/target/1-17-jvm-2.13 \
+          core/target/1-17-jvm-3 \
+          core/target/1-17-native-2.13 \
+          core/target/1-17-native-3 \
           joda/target/1-13-jvm-2.12 \
           joda/target/1-14-jvm-2.12 \
           joda/target/1-14-jvm-2.13 \
@@ -69,6 +77,9 @@ jobs:
           joda/target/1-16-jvm-2.12 \
           joda/target/1-16-jvm-2.13 \
           joda/target/1-16-jvm-3 \
+          joda/target/1-17-jvm-2.12 \
+          joda/target/1-17-jvm-2.13 \
+          joda/target/1-17-jvm-3 \
           project/target \
           target
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,10 +31,12 @@ def commonSettings(subProject: Option[String]): Seq[Setting[_]] = {
   Seq(
     name := artifact.value,
     mimaPreviousArtifacts := {
-      if (ScalaCheckAxis.current.value.scalaCheckVersion == ScalaCheckAxis.v1_16.scalaCheckVersion)
-        Set.empty
-      else
-        Set(organization.value %% artifact.value % mimaPreviousVersion.value)
+      val scVersion = ScalaCheckAxis.current.value.scalaCheckVersion
+      CrossVersion.partialVersion(scVersion) match {
+        case Some((1, 16 | 17)) => Set.empty
+        case _ =>
+          Set(organization.value %% artifact.value % mimaPreviousVersion.value)
+      }
     },
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem](
@@ -120,6 +122,14 @@ lazy val core = projectMatrix
         ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
     )
   )
+  .customRow(
+    scalaVersions = ScalaCheckAxis.v1_17.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1_17, VirtualAxis.jvm),
+    settings = Seq(
+      libraryDependencies +=
+        ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
+    )
+  )
   .jsPlatform(
     scalaVersions = ScalaCheckAxis.v1_15.scalaVersions,
     axisValues = Seq(ScalaCheckAxis.v1_15),
@@ -136,6 +146,14 @@ lazy val core = projectMatrix
         ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
     )
   )
+  .jsPlatform(
+    scalaVersions = ScalaCheckAxis.v1_17.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1_17),
+    settings = Seq(
+      libraryDependencies +=
+        ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
+    )
+  )
   .nativePlatform(
     scalaVersions = ScalaCheckAxis.v1_15.scalaVersions.filterNot(_ == Scala_2_12),
     axisValues = Seq(ScalaCheckAxis.v1_15),
@@ -147,6 +165,14 @@ lazy val core = projectMatrix
   .nativePlatform(
     scalaVersions = ScalaCheckAxis.v1_16.scalaVersions.filterNot(_ == Scala_2_12),
     axisValues = Seq(ScalaCheckAxis.v1_16),
+    settings = Seq(
+      libraryDependencies +=
+        ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
+    )
+  )
+  .nativePlatform(
+    scalaVersions = ScalaCheckAxis.v1_17.scalaVersions.filterNot(_ == Scala_2_12),
+    axisValues = Seq(ScalaCheckAxis.v1_17),
     settings = Seq(
       libraryDependencies +=
         ScalaCheckAxis.current.value.scalaTestPlusScalaCheck(scalaVersion.value)
@@ -181,5 +207,10 @@ lazy val joda = projectMatrix
   .customRow(
     scalaVersions = ScalaCheckAxis.v1_16.scalaVersions,
     axisValues = Seq(ScalaCheckAxis.v1_16, VirtualAxis.jvm),
+    settings = Nil
+  )
+  .customRow(
+    scalaVersions = ScalaCheckAxis.v1_17.scalaVersions,
+    axisValues = Seq(ScalaCheckAxis.v1_17, VirtualAxis.jvm),
     settings = Nil
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,25 +9,13 @@ object Dependencies {
   final val Scala_2_13 = "2.13.6"
   final val Scala_3 = "3.1.1"
 
-  private final val ScalaTest_2_2 = "2.2.6"
-
   // Newer versions of ScalaTest separate the scalatestplus %% scalacheck-1-X dependencies,
   // but do not support ScalaCheck 1.13.x
   // Once we no longer support ScalaCheck 1.13.x, we can upgrade to the latest version of
   // ScalaTest and always pull in the appropriate ScalaTestPlus artifact for ScalaCheck >= 1.14
   private final val ScalaTest_3_0 = "3.0.5"
-  private final val ScalaTest_3_2 = "3.2.9"
-  private final val scalaTest_3_2_14 = "3.2.14"
-
-  private def scalaTestPlusScalaCheckVersion(
-    scalaVer: String,
-    scalaCheckVersion: String
-  ) =
-    (CrossVersion.partialVersion(scalaVer), scalaCheckVersion) match {
-      case (_, ScalaCheckAxis.v1_16.scalaCheckVersion) => "3.2.14.0"
-      case (Some((3, _)), _) => "3.2.10.0"
-      case _ => "3.2.2.0"
-    }
+  private final val ScalaTest_3_2_9 = "3.2.9"
+  private final val ScalaTest_3_2_14 = "3.2.14"
 
   private final val IzumiReflectVersion = "1.1.2"
   private final val JodaTimeVersion = "2.10.10"
@@ -61,15 +49,22 @@ object Dependencies {
     def scalaTest: ModuleID =
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test
 
-    def scalaTestPlusScalaCheck(scalaVer: String): ModuleID =
-      "org.scalatestplus" %% s"scalacheck-$id" % scalaTestPlusScalaCheckVersion(scalaVer, scalaCheckVersion) % Test
+    def scalaTestPlusScalaCheck(scalaVer: String): ModuleID = {
+      val version = (CrossVersion.partialVersion(scalaVer), CrossVersion.partialVersion(scalaCheckVersion)) match {
+        case (_, Some((1, 16 | 17))) => "3.2.14.0"
+        case (Some((3, _)), _) => "3.2.10.0"
+        case _ => "3.2.2.0"
+      }
+      "org.scalatestplus" %% s"scalacheck-$id" % version % Test
+    }
   }
 
   object ScalaCheckAxis extends CurrentAxis[ScalaCheckAxis] {
     val v1_13 = ScalaCheckAxis("1-13", "1.13.5", ScalaTest_3_0, Seq(Scala_2_12))
-    val v1_14 = ScalaCheckAxis("1-14", "1.14.3", ScalaTest_3_2, Seq(Scala_2_12, Scala_2_13))
-    val v1_15 = ScalaCheckAxis("1-15", "1.15.4", ScalaTest_3_2, Seq(Scala_2_12, Scala_2_13, Scala_3))
-    val v1_16 = ScalaCheckAxis("1-16", "1.16.0", scalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
+    val v1_14 = ScalaCheckAxis("1-14", "1.14.3", ScalaTest_3_2_9, Seq(Scala_2_12, Scala_2_13))
+    val v1_15 = ScalaCheckAxis("1-15", "1.15.4", ScalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
+    val v1_16 = ScalaCheckAxis("1-16", "1.16.0", ScalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
+    val v1_17 = ScalaCheckAxis("1-17", "1.17.0", ScalaTest_3_2_14, Seq(Scala_2_12, Scala_2_13, Scala_3))
   }
 
   abstract class CurrentAxis[T : ClassTag] {


### PR DESCRIPTION
## Description

An alternative implementation to support ScalaCheck 1.17.0 to https://github.com/rallyhealth/scalacheck-ops/pull/64

Adds an artifact for scalacheck 1.17 by using the 1-17 suffix.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
