### PR TITLE
Add scmInfo to build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ scalaVersion := Scala_2_13
 
 ThisBuild / organization := "com.rallyhealth"
 ThisBuild / organizationName := "Rally Health"
-
+ThisBuild / scmInfo := Some(
+  ScmInfo(url("https://github.com/rallyhealth/scalacheck-ops"), "scm:git:git@github.com:rallyhealth/scalacheck-ops.git")
+)
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2


### PR DESCRIPTION
## Description

This is to hopefully put scalacheck-ops versions back up on [scaladex](https://index.scala-lang.org/rallyhealth/scalacheck-ops)
I am following the instructions on https://github.com/scalacenter/scaladex-contrib for how to do this.

## Type of change

- [x] Bug fix
- [x] Upgrade