### PR TITLE
Add scala-steward github workflow

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,37 @@
+name: Scala Steward
+on:
+  schedule:
+    # This workflow will launch every day at 4am
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      update_pull_requests:
+        description: Update Scala Steward generated PRs
+        required: true
+        type: choice
+        options:
+          - always
+          - on-conflicts
+          - never
+        default: always
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Commit Title
+        shell: bash
+        env:
+          UPDATE_PULL_REQUEST: ${{ github.event.inputs.update_pull_requests || 'on-conflicts' }}
+        run: |
+          # Add commits.message config to ~/.scala-steward.conf
+          echo "
+            commits.message = \"⬆️ \${artifactName} \${currentVersion} to \${nextVersion}\"
+            updatePullRequests = \"$UPDATE_PULL_REQUEST\"
+          " | sed 's/^ *//' > ~/.scala-steward.conf
+          cat ~/.scala-steward.conf
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          author-email: scala-steward@rallyhealth.com
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-config: /home/runner/.scala-steward.conf


### PR DESCRIPTION
## Description

Without approval of Github Actions for the rallyhealth organization ([JIRA](https://jira.rallyhealth.com/browse/DEVSECOPS-1363)), the PRs opened by Scala Steward will not trigger CI.

## Type of change

- [x] CI / CD

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
